### PR TITLE
fix: simplify app.run() method and add development warning  - Remove complex granian subprocess logic and temporary file handling - Use uvicorn as default server with simple import check - Add warning that app.run() is inefficient and only for testing - Encourage use of nexios CLI or ASGI servers for development/production - Reduce method from ~80 lines to ~15 lines for better maintainability - Remove rload parameter and simplify error handling  The method now provides a simple testing experience while guiding users toward proper deployment tools.  closes #150

### DIFF
--- a/examples/simple_app.py
+++ b/examples/simple_app.py
@@ -14,42 +14,45 @@ from nexios.http import Request, Response
 app = NexiosApp(
     title="Simple Nexios App",
     version="1.0.0",
-    description="A simple example of Nexios usage"
+    description="A simple example of Nexios usage",
 )
+
 
 @app.get("/")
 async def home(request: Request, response: Response):
     """Home endpoint"""
-    return response.json({
-        "message": "Welcome to Nexios!",
-        "framework": "Nexios",
-        "version": "1.0.0"
-    })
+    return response.json(
+        {"message": "Welcome to Nexios!", "framework": "Nexios", "version": "1.0.0"}
+    )
+
 
 @app.get("/users/{user_id:int}")
 async def get_user(request: Request, response: Response):
     """Get user by ID"""
     user_id = request.path_params.user_id
-    return response.json({
-        "user_id": user_id,
-        "name": f"User {user_id}",
-        "email": f"user{user_id}@example.com"
-    })
+    return response.json(
+        {
+            "user_id": user_id,
+            "name": f"User {user_id}",
+            "email": f"user{user_id}@example.com",
+        }
+    )
+
 
 @app.post("/users")
 async def create_user(request: Request, response: Response):
     """Create a new user"""
     user_data = request.json()
-    return response.json({
-        "message": "User created successfully",
-        "user": user_data
-    }, status=201)
+    return response.json(
+        {"message": "User created successfully", "user": user_data}, status=201
+    )
+
 
 if __name__ == "__main__":
     print("Starting Simple Nexios App...")
     print("This app demonstrates the correct usage of app.run()")
     print("The method now uses uvicorn.run(app, ...) directly")
     print("This fixes the import error when deployed to PyPI")
-    
+
     # This should work correctly now
-    app.run(host="127.0.0.1", port=8000) 
+    app.run(host="127.0.0.1", port=8000)

--- a/nexios/application.py
+++ b/nexios/application.py
@@ -2272,11 +2272,14 @@ class NexiosApp(object):
             if result.returncode == 0:
                 # Granian is available, use it
                 # For granian, we need to create a temporary file since it doesn't have a direct API
-                import tempfile
                 import os
-                
-                with tempfile.NamedTemporaryFile(mode="w", suffix=".py", delete=False) as f:
-                    f.write(f"""import sys
+                import tempfile
+
+                with tempfile.NamedTemporaryFile(
+                    mode="w", suffix=".py", delete=False
+                ) as f:
+                    f.write(
+                        f"""import sys
 import os
 
 # Add the current directory to Python path
@@ -2289,7 +2292,8 @@ app = {self.__class__.__name__}()
 # Make the app available for the server
 if __name__ == "__main__":
     pass
-""")
+"""
+                    )
                     temp_file = f.name
 
                 try:
@@ -2342,15 +2346,9 @@ if __name__ == "__main__":
             if result.returncode == 0:
                 # Uvicorn is available, use it directly with the app instance
                 import uvicorn
-                
+
                 print(f"Starting server with uvicorn: {host}:{port}")
-                uvicorn.run(
-                    self,
-                    host=host,
-                    port=port,
-                    reload=reload,
-                    **kwargs
-                )
+                uvicorn.run(self, host=host, port=port, reload=reload, **kwargs)
                 return
         except (
             subprocess.TimeoutExpired,

--- a/nexios/application.py
+++ b/nexios/application.py
@@ -2262,18 +2262,19 @@ class NexiosApp(object):
             **kwargs: Additional keyword arguments for uvicorn.
         """
         import warnings
-        
+
         warnings.warn(
             "app.run() is inefficient and only for testing. For development and production, use:\n"
             "- nexios run --host 0.0.0.0 --port 8000\n"
             "- uvicorn app:app --host 0.0.0.0 --port 8000\n"
             "- granian app:app --host 0.0.0.0 --port 8000",
             UserWarning,
-            stacklevel=2
+            stacklevel=2,
         )
-        
+
         try:
             import uvicorn
+
             print(f"Starting server with uvicorn: {host}:{port}")
             uvicorn.run(self, host=host, port=port, reload=reload, **kwargs)
         except ImportError:

--- a/nexios/cli/commands/ping.py
+++ b/nexios/cli/commands/ping.py
@@ -9,9 +9,15 @@ from typing import Optional
 
 import click
 
-from nexios.cli.utils import _echo_error, _echo_info, _echo_success, _echo_warning, load_config_module
+from nexios.cli.utils import (
+    _echo_error,
+    _echo_info,
+    _echo_success,
+    _echo_warning,
+    _load_app_from_path,
+    load_config_module,
+)
 from nexios.testing.client import Client
-from nexios.cli.utils import _load_app_from_path
 
 
 @click.command()
@@ -31,20 +37,21 @@ def ping(
     route_path: str,
     cli_app_path: Optional[str] = None,
     config_path: Optional[str] = None,
-    method: str = "GET"
+    method: str = "GET",
 ):
     """
     Ping a route in the Nexios app to check if it exists (returns status code).
-    
+
     Examples:
       nexios ping /about --app sandbox:app
       nexios ping /api/users --config config.py
     """
+
     async def _ping():
         try:
             # Load config (returns None, {} if file doesn't exist)
             app, config = load_config_module(config_path)
-            
+
             # Resolve app path (CLI argument takes precedence over config)
             resolved_app_path = cli_app_path or config.get("app_path")
             if not resolved_app_path:
@@ -65,7 +72,7 @@ def ping(
             async with Client(app) as client:
                 resp = await client.request(method.upper(), route_path)
                 click.echo(f"{route_path} [{method.upper()}] -> {resp.status_code}")
-                
+
                 if resp.status_code == 200:
                     _echo_success("Route exists and is reachable")
                 elif resp.status_code == 404:
@@ -78,4 +85,3 @@ def ping(
             sys.exit(1)
 
     asyncio.run(_ping())
-

--- a/nexios/cli/commands/shell.py
+++ b/nexios/cli/commands/shell.py
@@ -7,8 +7,13 @@ import sys
 
 import click
 
-from nexios.cli.utils import _echo_info, _echo_warning, load_config_module
-from nexios.cli.utils import _echo_error, _load_app_from_path
+from nexios.cli.utils import (
+    _echo_error,
+    _echo_info,
+    _echo_warning,
+    _load_app_from_path,
+    load_config_module,
+)
 
 
 @click.command()
@@ -45,7 +50,7 @@ def shell(app_path: str, config_path: str = None, ipython: bool = False):
     try:
         # Load config if provided (will return empty dict if file doesn't exist)
         app, config = load_config_module(config_path)
-        
+
         # If app_path was provided in config, use it (CLI arg takes precedence)
         if "app_path" in config and not app_path:
             app_path = config["app_path"]
@@ -70,6 +75,7 @@ def shell(app_path: str, config_path: str = None, ipython: bool = False):
         # Try to import common modules that might be useful
         try:
             from nexios.testing.client import Client
+
             shell_vars["Client"] = Client
             _echo_info("Test client available as 'Client'")
         except ImportError:
@@ -78,6 +84,7 @@ def shell(app_path: str, config_path: str = None, ipython: bool = False):
         try:
             from nexios.http.request import Request
             from nexios.http.response import Response
+
             shell_vars["Request"] = Request
             shell_vars["Response"] = Response
             _echo_info("Request/Response classes available")
@@ -86,6 +93,7 @@ def shell(app_path: str, config_path: str = None, ipython: bool = False):
 
         try:
             from nexios.config import MakeConfig
+
             shell_vars["MakeConfig"] = MakeConfig
             _echo_info("MakeConfig available for configuration")
         except ImportError:
@@ -109,11 +117,13 @@ def shell(app_path: str, config_path: str = None, ipython: bool = False):
 def _try_start_ipython_shell(shell_vars: dict) -> bool:
     """Try to start IPython shell."""
     try:
-        import IPython #noqa: F401
+        import IPython  # noqa: F401
         from IPython.terminal.embed import InteractiveShellEmbed
 
         _echo_info("Starting IPython shell...")
-        _echo_info("Available variables: app, config, Client, Request, Response, MakeConfig")
+        _echo_info(
+            "Available variables: app, config, Client, Request, Response, MakeConfig"
+        )
         _echo_info("Type 'exit' or press Ctrl+D to exit")
 
         banner = """
@@ -152,7 +162,9 @@ def _try_start_regular_shell(shell_vars: dict) -> bool:
         import code
 
         _echo_info("Starting Python shell...")
-        _echo_info("Available variables: app, config, Client, Request, Response, MakeConfig")
+        _echo_info(
+            "Available variables: app, config, Client, Request, Response, MakeConfig"
+        )
         _echo_info("Type 'exit()' or press Ctrl+D to exit")
 
         banner = """

--- a/nexios/cli/commands/urls.py
+++ b/nexios/cli/commands/urls.py
@@ -31,15 +31,13 @@ def urls(app_path: str = None, config_path: str = None):
     try:
         # Load config (optional)
         app, config = load_config_module(config_path)
-        
+
         # If app_path wasn't provided in CLI args, check config
         if not app_path and "app_path" in config:
             app_path = config["app_path"]
-            
+
         if not app_path:
-            _echo_error(
-                "App path must be specified with --app or in config file."
-            )
+            _echo_error("App path must be specified with --app or in config file.")
             sys.exit(1)
 
         # Load app instance using app_path

--- a/nexios/cli/utils.py
+++ b/nexios/cli/utils.py
@@ -217,7 +217,7 @@ def load_config_module(config_path: Optional[str] = None) -> Tuple[Any, Dict[str
     """
     config_file = config_path or os.path.join(os.getcwd(), "nexios.config.py")
     if not os.path.exists(config_file):
-        return  None, {}
+        return None, {}
 
     spec = importlib.util.spec_from_file_location("nexios_config", config_file)
     if spec is None or spec.loader is None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -188,6 +188,7 @@ known-first-party = ["nexios"]
 [tool.uv.workspace]
 members = [
     "oneapp",
+    "dev_App",
 ]
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -4,8 +4,8 @@ requires-python = ">=3.13"
 
 [manifest]
 members = [
+    "dev-app",
     "nexios",
-    "oneapp",
 ]
 
 [[package]]
@@ -110,6 +110,17 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/1f/56/4ee027d5965fc7fc126d7ec1187529cc30cc7d740846e1ecb5e92d31b224/coverage-7.9.1-cp313-cp313t-win_arm64.whl", hash = "sha256:18a0912944d70aaf5f399e350445738a1a20b50fbea788f640751c2ed9208b6c", size = 214392, upload-time = "2025-06-13T13:02:07.642Z" },
     { url = "https://files.pythonhosted.org/packages/08/b8/7ddd1e8ba9701dea08ce22029917140e6f66a859427406579fd8d0ca7274/coverage-7.9.1-py3-none-any.whl", hash = "sha256:66b974b145aa189516b6bf2d8423e888b742517d37872f6ee4c5be0073bd9a3c", size = 204000, upload-time = "2025-06-13T13:02:27.173Z" },
 ]
+
+[[package]]
+name = "dev-app"
+version = "0.1.0"
+source = { virtual = "dev_App" }
+dependencies = [
+    { name = "nexios" },
+]
+
+[package.metadata]
+requires-dist = [{ name = "nexios", editable = "." }]
 
 [[package]]
 name = "ghp-import"
@@ -352,7 +363,7 @@ wheels = [
 
 [[package]]
 name = "nexios"
-version = "2.6.0"
+version = "2.6.2a1"
 source = { editable = "." }
 dependencies = [
     { name = "anyio" },
@@ -425,11 +436,6 @@ requires-dist = [
     { name = "uvicorn", specifier = ">=0.27.0" },
 ]
 provides-extras = ["templating", "jwt", "granian", "all", "dev"]
-
-[[package]]
-name = "oneapp"
-version = "0.1.0"
-source = { virtual = "oneapp" }
 
 [[package]]
 name = "packaging"


### PR DESCRIPTION
fix: simplify app.run() method and add development warning

- Remove complex granian subprocess logic and temporary file handling
- Use uvicorn as default server with simple import check
- Add warning that app.run() is inefficient and only for testing
- Encourage use of nexios CLI or ASGI servers for development/production
- Reduce method from ~80 lines to ~15 lines for better maintainability
- Remove rload parameter and simplify error handling

The method now provides a simple testing experience while guiding users
toward proper deployment tools.