### PR TITLE
fix: Fix all pytest warnings

### DIFF
--- a/examples/auth_router.py
+++ b/examples/auth_router.py
@@ -1,4 +1,4 @@
-from nexios import get_application
+from nexios import NexiosApp
 from nexios.routing import Router
 
 auth_router = Router()
@@ -16,7 +16,7 @@ async def login(req, res):
     return res.json({"error": "Invalid credentials"}, status_code=401)
 
 
-app = get_application()
+app = NexiosApp()
 app.mount_router("/auth", auth_router)
 
 if __name__ == "__main__":

--- a/examples/basic_rest_api.py
+++ b/examples/basic_rest_api.py
@@ -1,6 +1,6 @@
-from nexios import get_application
+from nexios import NexiosApp
 
-app = get_application()
+app = NexiosApp()
 
 
 @app.get("/api/items")

--- a/examples/file_router/main.py
+++ b/examples/file_router/main.py
@@ -6,10 +6,10 @@ from nexios.file_router.html import configure_templates
 BASE_DIR = Path(__file__).parent.parent.parent
 sys.path.append(str(BASE_DIR))
 
-from nexios import get_application
+from nexios import NexiosApp
 from nexios.file_router import FileRouter
 
-app = get_application()
+app = NexiosApp()
 
 FileRouter(app, config={"root": "./routes", "exempt_paths": ["./routes/posts"]})
 

--- a/examples/file_upload.py
+++ b/examples/file_upload.py
@@ -1,6 +1,6 @@
-from nexios import get_application
+from nexios import NexiosApp
 
-app = get_application()
+app = NexiosApp()
 
 
 @app.post("/upload")

--- a/examples/form_data_validation.py
+++ b/examples/form_data_validation.py
@@ -1,8 +1,8 @@
 from pydantic import BaseModel, EmailStr, ValidationError
 
-from nexios import get_application
+from nexios import NexiosApp
 
-app = get_application()
+app = NexiosApp()
 
 
 class UserRegistration(BaseModel):

--- a/examples/lifespan_example.py
+++ b/examples/lifespan_example.py
@@ -14,7 +14,7 @@ import asyncio
 import logging
 from contextlib import asynccontextmanager
 
-from nexios import get_application
+from nexios import NexiosApp
 from nexios.http.request import Request
 from nexios.http.response import Response
 
@@ -98,7 +98,7 @@ async def lifespan_context(app):
 # Create application instances to demonstrate different approaches
 
 # 1. Application with regular startup/shutdown handlers
-regular_app = get_application(title="Regular Handlers Example")
+regular_app = NexiosApp(title="Regular Handlers Example")
 
 
 @regular_app.on_startup()
@@ -130,11 +130,11 @@ async def shutdown_handler2():
 
 
 # 2. Application with custom lifespan context manager
-custom_app = get_application(title="Custom Lifespan Example", lifespan=lifespan_context)
+custom_app = NexiosApp(title="Custom Lifespan Example", lifespan=lifespan_context)
 
 
 # 3. Application demonstrating error handling
-error_app = get_application(title="Error Handling Example")
+error_app = NexiosApp(title="Error Handling Example")
 
 
 @error_app.on_startup()
@@ -153,7 +153,7 @@ async def error_cleanup():
 
 
 # Main application that combines regular handlers and custom lifespan
-app = get_application(title="Nexios Lifespan Demo", lifespan=lifespan_context)
+app = NexiosApp(title="Nexios Lifespan Demo", lifespan=lifespan_context)
 
 
 # Add some regular handlers too (these won't run when custom lifespan is used)

--- a/examples/streaming_middleware.py
+++ b/examples/streaming_middleware.py
@@ -1,6 +1,6 @@
-from nexios import get_application
+from nexios import NexiosApp
 
-app = get_application()
+app = NexiosApp()
 
 
 async def log_request(req, res, next):

--- a/nexios/templates/beta/main.py
+++ b/nexios/templates/beta/main.py
@@ -1,11 +1,11 @@
-from nexios import get_application
+from nexios import NexiosApp
 from nexios.routing import Routes
 
 from config import app_config
 from routes.index import index
 
 # Create the application
-app = get_application(title="{{project_name_title}}", config=app_config)
+app = NexiosApp(title="{{project_name_title}}", config=app_config)
 
 
 @app.on_startup

--- a/nexios/testing/client.py
+++ b/nexios/testing/client.py
@@ -14,6 +14,8 @@ _RequestData = typing.Mapping[str, typing.Union[str, typing.Iterable[str], bytes
 
 
 class Client(httpx.AsyncClient):
+    __test__ = False
+
     def __init__(
         self,
         app: "NexiosApp",
@@ -76,6 +78,9 @@ class Client(httpx.AsyncClient):
         ] = httpx._client.USE_CLIENT_DEFAULT,  # type: ignore
         extensions: Union[Dict[str, typing.Any], None] = None,
     ) -> httpx.Response:
+        if cookies:
+            self.cookies.update(cookies)
+
         response = await super().request(
             method,
             url,
@@ -85,7 +90,6 @@ class Client(httpx.AsyncClient):
             json=json,
             params=params,
             headers=headers,
-            cookies=cookies,
             auth=auth,
             follow_redirects=follow_redirects,
             timeout=timeout,
@@ -154,7 +158,6 @@ class Client(httpx.AsyncClient):
             json=json,
             params=params,
             headers=headers,
-            cookies=cookies,
             auth=auth,
             follow_redirects=follow_redirects,
             timeout=timeout,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -93,7 +93,6 @@ nexios = "nexios.cli:cli"
 
 [tool.pytest.ini_options]
 asyncio_mode = "auto"
-asyncio_fixture_scope = "function"
 addopts = "--ignore=benchmarks"
 
 [tool.mypy]

--- a/test/test_application.py
+++ b/test/test_application.py
@@ -1,13 +1,13 @@
 import pytest
 
-from nexios import NexiosApp, get_application
+from nexios import NexiosApp
 from nexios.dependencies import Context, Depend
 from nexios.http import Request, Response
 from nexios.routing import Router
 from nexios.testing import Client
 from nexios.views import APIView
 
-app: NexiosApp = get_application()
+app: NexiosApp = NexiosApp()
 router = Router("/mounted")
 
 

--- a/test/test_auth.py
+++ b/test/test_auth.py
@@ -1,19 +1,20 @@
 import pytest
 
-from nexios import get_application
 from nexios.application import NexiosApp
 from nexios.auth.backends.jwt import create_jwt, decode_jwt
 from nexios.auth.base import AuthenticationBackend, SimpleUser
 from nexios.auth.decorator import auth, has_permission
 from nexios.auth.exceptions import PermissionDenied
-from nexios.config.base import MakeConfig
+from nexios.config import MakeConfig, set_config
 from nexios.http import Request, Response
 from nexios.testing import Client
 
 
 @pytest.fixture
 async def test_client():
-    app = get_application(MakeConfig({"secret_key": "1234"}))
+    config = MakeConfig({"secret_key": "1234"})
+    set_config(config)
+    app = NexiosApp()
     async with Client(app) as client:
         yield client, app
 

--- a/test/test_cors.py
+++ b/test/test_cors.py
@@ -1,8 +1,8 @@
 # test_cors_with_app.py
 import pytest
 
-from nexios import get_application
-from nexios.config import MakeConfig
+from nexios import NexiosApp
+from nexios.config import MakeConfig, set_config
 from nexios.middleware.cors import CORSMiddleware
 from nexios.testing import Client
 
@@ -22,7 +22,8 @@ async def cors_app():
             }
         }
     )
-    app = get_application(config)
+    set_config(config)
+    app = NexiosApp(config)
 
     # Add test route
     @app.get("/test")
@@ -115,7 +116,8 @@ async def test_preflight_request_disallowed_header(client):
 async def test_wildcard_origin():
     # Test app with wildcard origin
     config = MakeConfig({"cors": {"allow_origins": ["*"], "allow_methods": ["*"]}})
-    app = get_application(config)
+    set_config(config)
+    app = NexiosApp(config)
 
     @app.get("/wildcard")
     async def wildcard_route(req, res):
@@ -139,7 +141,8 @@ async def test_no_cors_headers_without_origin():
     config = MakeConfig(
         {"cors": {"allow_origins": ["http://example.com"], "allow_methods": ["GET"]}}
     )
-    app = get_application(config)
+    set_config(config)
+    app = NexiosApp(config)
 
     @app.get("/no-origin")
     async def no_origin_route(req, res):

--- a/test/test_dependencies.py
+++ b/test/test_dependencies.py
@@ -3,14 +3,14 @@ from typing import Optional
 import pytest
 from pydantic import BaseModel
 
-from nexios import Depend, get_application
+from nexios import Depend, NexiosApp
 from nexios.http import Request, Response
 from nexios.testing import Client
 
 
 @pytest.fixture
 async def di_client():
-    app = get_application()
+    app = NexiosApp()
     async with Client(app) as client:
         yield client, app
 
@@ -243,7 +243,7 @@ async def test_global_dependency(di_client):
     async def global_dep():
         raise CustomError("global-value")
 
-    app = get_application(dependencies=[Depend(global_dep)])
+    app = NexiosApp(dependencies=[Depend(global_dep)])
 
     @app.get("/di/global")
     async def global_route(req: Request, res: Response):

--- a/test/test_event.py
+++ b/test/test_event.py
@@ -4,7 +4,7 @@ from unittest.mock import Mock, call
 
 import pytest
 
-from nexios import get_application
+from nexios import NexiosApp
 from nexios.events import (
     EventEmitter,
     EventPhase,
@@ -15,7 +15,7 @@ from nexios.events import (
 # Fixture for app with event emitter, ensuring clean state
 @pytest.fixture
 def app_with_emitter():
-    app = get_application()
+    app = NexiosApp()
     app.emitter = EventEmitter()
     yield app
     app.emitter.remove_all_events()

--- a/test/test_exception_handlers.py
+++ b/test/test_exception_handlers.py
@@ -2,7 +2,7 @@ from typing import Tuple
 
 import pytest
 
-from nexios import NexiosApp, get_application
+from nexios import NexiosApp
 from nexios.exceptions import HTTPException, NotFoundException
 from nexios.http import Request, Response
 from nexios.testing import Client
@@ -10,7 +10,7 @@ from nexios.testing import Client
 
 @pytest.fixture
 async def async_client():
-    app = get_application()  # Fresh app instance for each test
+    app = NexiosApp()  # Fresh app instance for each test
     async with Client(app, log_requests=True) as c:
         yield c, app
 

--- a/test/test_form_parser.py
+++ b/test/test_form_parser.py
@@ -2,7 +2,7 @@ from typing import AsyncGenerator
 
 import pytest
 
-from nexios import get_application
+from nexios import NexiosApp
 from nexios.http import Request, Response
 from nexios.http.formparsers import FormParser, MultiPartException, MultiPartParser
 from nexios.structs import FormData, Headers, UploadedFile
@@ -17,7 +17,7 @@ if not hasattr(MultiPartParser, "max_files"):
     MultiPartParser.max_files = 1000
 
 # Create an application instance for testing
-app = get_application()
+app = NexiosApp()
 
 
 # Define test endpoints for form submission

--- a/test/test_grouping.py
+++ b/test/test_grouping.py
@@ -1,14 +1,14 @@
 # test_grouping.py
 import pytest
 
-from nexios import get_application
+from nexios import NexiosApp
 from nexios.routing import Group, Routes
 from nexios.testing import Client
 
 
 @pytest.fixture
 async def async_client():
-    app = get_application()
+    app = NexiosApp()
     async with Client(app) as c:
         yield c, app
 

--- a/test/test_middleware.py
+++ b/test/test_middleware.py
@@ -4,7 +4,7 @@ from unittest.mock import MagicMock, Mock, patch
 
 import pytest
 
-from nexios import get_application
+from nexios import NexiosApp
 from nexios.http import Request, Response
 from nexios.middleware.base import BaseMiddleware
 from nexios.middleware.common import CommonMiddleware
@@ -21,7 +21,7 @@ class TestBaseMiddleware:
         middleware = BaseMiddleware()
         assert middleware is not None
 
-    def test_base_middleware_call(self):
+    async def test_base_middleware_call(self):
         """Test BaseMiddleware __call__ method"""
         middleware = BaseMiddleware()
         request = Mock()
@@ -31,7 +31,7 @@ class TestBaseMiddleware:
         async def mock_call_next():
             return response
 
-        result = middleware(request, response, mock_call_next)
+        result = await middleware(request, response, mock_call_next)
         assert result
 
 
@@ -41,7 +41,7 @@ class TestCommonMiddleware:
     @pytest.fixture
     async def app_with_common_middleware(self):
         """Create app with CommonMiddleware"""
-        app = get_application()
+        app = NexiosApp()
         app.add_middleware(CommonMiddleware())
         async with Client(app) as client:
             yield client, app
@@ -99,7 +99,7 @@ class TestCommonMiddleware:
 
         # Test with large content
         large_data = "x" * 1024 * 1024  # 1MB
-        response = await client.post("/test", data=large_data)
+        response = await client.post("/test", content=large_data)
         # Should handle large content appropriately
         assert response.status_code in [200, 413]  # 413 if limit exceeded
 
@@ -110,7 +110,7 @@ class TestCommonMiddleware:
 #     @pytest.fixture
 #     async def app_with_gzip_middleware(self):
 #         """Create app with GzipMiddleware"""
-#         app = get_application()
+#         app = NexiosApp()
 #         app.add_middleware(GZipMiddleware())
 #         async with Client(app) as client:
 #             yield client, app
@@ -202,7 +202,7 @@ class TestSecurityMiddleware:
     @pytest.fixture
     async def app_with_security_middleware(self):
         """Create app with SecurityMiddleware"""
-        app = get_application()
+        app = NexiosApp()
         app.add_middleware(SecurityMiddleware())
         async with Client(app) as client:
             yield client, app
@@ -260,7 +260,7 @@ class TestMiddlewareIntegration:
     @pytest.fixture
     async def app_with_multiple_middleware(self):
         """Create app with multiple middleware"""
-        app = get_application()
+        app = NexiosApp()
         app.add_middleware(SecurityMiddleware())
         # app.add_middleware(GZipMiddleware())
         app.add_middleware(CommonMiddleware())

--- a/test/test_middlewares.py
+++ b/test/test_middlewares.py
@@ -1,10 +1,10 @@
 import pytest
 
-from nexios import NexiosApp, get_application
+from nexios import NexiosApp
 from nexios.http import Request, Response
 from nexios.testing import Client
 
-app: NexiosApp = get_application()
+app: NexiosApp = NexiosApp()
 
 
 @pytest.fixture(autouse=True)

--- a/test/test_pagination.py
+++ b/test/test_pagination.py
@@ -1,6 +1,6 @@
 import pytest
 
-from nexios import get_application
+from nexios import NexiosApp
 from nexios.http import Request, Response
 from nexios.pagination import AsyncListDataHandler as ListDataHandler
 from nexios.pagination import (
@@ -18,7 +18,7 @@ from nexios.testing import Client
 
 @pytest.fixture
 async def test_client():
-    app = get_application()
+    app = NexiosApp()
     async with Client(app) as client:
         yield client, app
 

--- a/test/test_pydantic_utils.py
+++ b/test/test_pydantic_utils.py
@@ -1,7 +1,7 @@
 from typing import Optional
 
 import pytest
-from pydantic import BaseModel, ValidationError
+from pydantic import BaseModel
 
 from nexios import NexiosApp
 from nexios.testing import Client
@@ -131,7 +131,7 @@ class TestPydanticErrorHandling:
         async def valid_route(request, response):
             data = await request.json
             user = UserModel(**data)
-            return response.json(user.dict())
+            return response.json(user.model_dump())
 
         # Test valid request
         response = await client.post("/valid", json={"name": "Test User", "age": 25})

--- a/test/test_request_objects.py
+++ b/test/test_request_objects.py
@@ -1,13 +1,13 @@
 import pytest
 
-from nexios import get_application
+from nexios import NexiosApp
 from nexios.http import Request, Response
 from nexios.testing import Client
 
 
 @pytest.fixture
 async def test_client():
-    app = get_application()
+    app = NexiosApp()
     async with Client(app) as client:
         yield client, app
 

--- a/test/test_response.py
+++ b/test/test_response.py
@@ -4,11 +4,11 @@ from pathlib import Path
 
 import pytest
 
-from nexios import NexiosApp, get_application
+from nexios import NexiosApp
 from nexios.http import Request, Response
 from nexios.testing import Client
 
-app: NexiosApp = get_application()
+app: NexiosApp = NexiosApp()
 
 
 @app.get("/response/text")

--- a/test/test_routing.py
+++ b/test/test_routing.py
@@ -1,6 +1,6 @@
 import pytest
 
-from nexios import get_application
+from nexios import NexiosApp
 from nexios.http import Request, Response
 from nexios.routing import Router, Routes
 from nexios.testing import Client
@@ -8,7 +8,7 @@ from nexios.testing import Client
 
 @pytest.fixture
 async def async_client():
-    app = get_application()  # Fresh app instance for each test
+    app = NexiosApp()  # Fresh app instance for each test
     async with Client(app, log_requests=True) as c:
         yield c, app
 

--- a/test/test_websockets.py
+++ b/test/test_websockets.py
@@ -84,6 +84,8 @@ async def test_websocket_close(mock_websocket):
 
 # Test WebSocket Consumer
 class TestConsumer(WebSocketConsumer):
+    __test__ = False
+
     encoding = "json"
 
     async def on_connect(self, websocket):


### PR DESCRIPTION
Warnings fixed:

```
======================================================= warnings summary ========================================================
.venv/lib/python3.13/site-packages/_pytest/config/__init__.py:1474
  /Users/dmb/code/nexios/.venv/lib/python3.13/site-packages/_pytest/config/__init__.py:1474: PytestConfigWarning: Unknown config option: asyncio_fixture_scope
  
    self._warn_or_fail_if_strict(f"Unknown config option: {key}\n")

nexios/__init__.py:196: 4 warnings
test/test_auth.py: 8 warnings
test/test_cors.py: 7 warnings
test/test_dependencies.py: 13 warnings
test/test_event.py: 4 warnings
test/test_exception_handlers.py: 10 warnings
test/test_grouping.py: 8 warnings
test/test_middleware.py: 7 warnings
test/test_pagination.py: 6 warnings
test/test_request_objects.py: 14 warnings
test/test_routing.py: 11 warnings
test/test_session.py: 3 warnings
  /Users/dmb/code/nexios/nexios/__init__.py:196: DeprecationWarning: get_application is deprecated. Please use NexiosApp instead.
    warnings.warn(

nexios/testing/client.py:16
  /Users/dmb/code/nexios/nexios/testing/client.py:16: PytestCollectionWarning: cannot collect test class 'Client' because it has a __init__ constructor (from: test/test_templating.py)
    class Client(httpx.AsyncClient):

test/test_websockets.py:86
  /Users/dmb/code/nexios/test/test_websockets.py:86: PytestCollectionWarning: cannot collect test class 'TestConsumer' because it has a __init__ constructor (from: test/test_websockets.py)
    class TestConsumer(WebSocketConsumer):

test/test_middleware.py::TestBaseMiddleware::test_base_middleware_call
  /Users/dmb/code/nexios/.venv/lib/python3.13/site-packages/_pytest/python.py:157: RuntimeWarning: coroutine 'BaseMiddleware.__call__' was never awaited
    result = testfunction(**testargs)
  Enable tracemalloc to get traceback where the object was allocated.
  See https://docs.pytest.org/en/stable/how-to/capture-warnings.html#resource-warnings for more info.

test/test_middleware.py::TestCommonMiddleware::test_common_middleware_content_length_limit
  /Users/dmb/code/nexios/.venv/lib/python3.13/site-packages/httpx/_models.py:408: DeprecationWarning: Use 'content=<...>' to upload raw bytes/text content.
    headers, stream = encode_request(

test/test_pydantic_utils.py::TestPydanticErrorHandling::test_valid_request
  /Users/dmb/code/nexios/test/test_pydantic_utils.py:134: PydanticDeprecatedSince20: The `dict` method is deprecated; use `model_dump` instead. Deprecated in Pydantic V2.0 to be removed in V3.0. See Pydantic V2 Migration Guide at https://errors.pydantic.dev/2.11/migration/
    return response.json(user.dict())

test/test_request_objects.py::test_cookies
  /Users/dmb/code/nexios/nexios/testing/client.py:79: DeprecationWarning: Setting per-request cookies=<...> is being deprecated, because the expected behaviour on cookie persistence is ambiguous. Set cookies directly on the client instance instead.
    response = await super().request(

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
=============================================== 245 passed, 102 warnings in 1.70s ===============================================
```