### PR TITLE
refactor(openapi): move OpenAPI documentation setup to routing  - Remove _setup_openapi method from NexiosApp class - Add get_instance function to obtain APIDocumentation instance - Move OpenAPI documentation logic to Router.add_route method - Update import statements in affected modulesDev

### DIFF
--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -190,7 +190,7 @@ async def hello_world(request, response):
         "status": "success"
     })
 
-# If you forget to use async def for your handler, Nexios will raise an error at startup.
+# If you forget to use async def for your handler, Nexios will run the handler in a threadpool
 
 # If you define two routes with the same path and method, Nexios will raise a conflict error at startup.
 

--- a/nexios/routing/http.py
+++ b/nexios/routing/http.py
@@ -576,9 +576,6 @@ class Router(BaseRouter):
             return await original_handler(*handler_args, **handler_kwargs)
 
         route.handler = wrapped_handler
-        match = next((r for r in self.routes if r.raw_path == route.raw_path and r.methods == route.methods),None)  #type:ignore
-        if match:
-            raise ValueError("Route already exists")
         self.routes.append(route)
         if getattr(route, "exclude_from_schema", False):
             return

--- a/nexios/routing/http.py
+++ b/nexios/routing/http.py
@@ -576,7 +576,9 @@ class Router(BaseRouter):
             return await original_handler(*handler_args, **handler_kwargs)
 
         route.handler = wrapped_handler
-
+        match = next((r for r in self.routes if r.raw_path == route.raw_path and r.methods == route.methods),None)  #type:ignore
+        if match:
+            raise ValueError("Route already exists")
         self.routes.append(route)
         if getattr(route, "exclude_from_schema", False):
             return


### PR DESCRIPTION
refactor(router): reorganize BaseRouter and BaseRoute

- Restructured BaseRouter and BaseRoute classes
- Updated type annotations and method signatures
- Improved type checking and flexibility in routing
- Prepped for implementing mount_routers and middleware

feat(application): add request_content_type parameter to routing methods

- Add request_content_type parameter to various routing methods in NexiosApp class
- Update Router class in http.py to include request_content_type parameter
- Improve type annotations and documentation for request_content_type parameter
- Refactor websocket routing logic in NexiosApp class