### PR TITLE
refactor(openapi): remove APIDocumentation singleton and unused imports

### DIFF
--- a/nexios/openapi/_builder.py
+++ b/nexios/openapi/_builder.py
@@ -28,12 +28,7 @@ if TYPE_CHECKING:
 
 
 class APIDocumentation:
-    _instance = None
-
-    def __new__(cls, *args: list[Any], **kwargs: dict[str, Any]):
-        if not cls._instance:
-            cls._instance = super().__new__(cls)
-        return cls._instance
+  
 
     def __init__(  # type: ignore
         self,
@@ -341,7 +336,4 @@ class APIDocumentation:
         )
 
 
-def get_instance() -> APIDocumentation:
-    if APIDocumentation._instance is None:  # type: ignore
-        APIDocumentation._instance = APIDocumentation()  # type: ignore
-    return APIDocumentation._instance  # type: ignore
+

--- a/nexios/routing/http.py
+++ b/nexios/routing/http.py
@@ -37,7 +37,6 @@ from nexios.events import AsyncEventEmitter
 from nexios.exceptions import NotFoundException
 from nexios.http import Request, Response
 from nexios.http.response import JSONResponse
-from nexios.openapi._builder import get_instance
 from nexios.openapi.models import Parameter, Path, Schema
 from nexios.structs import RouteParam, URLPath
 from nexios.types import ASGIApp, HandlerType, MiddlewareType, Receive, Scope, Send
@@ -535,7 +534,6 @@ class Router(BaseRouter):
             app.add_route(route)
             ```
         """
-        docs = get_instance()
         if not route:
             if (not path) or (not handler):
                 raise ValueError(
@@ -604,22 +602,7 @@ class Router(BaseRouter):
                 + self.root_path
                 + re.sub(r"\{(\w+):\w+\}", r"{\1}", route.raw_path)
             )
-            docs.document_endpoint(
-                path=full_path,
-                method=method,
-                tags=route.tags,  #  type: ignore
-                security=route.security,
-                summary=route.summary or "",
-                description=route.description,
-                request_body=route.request_model,
-                request_content_type=getattr(
-                    route, "request_content_type", "application/json"
-                ),
-                parameters=parameters,  # type:ignore
-                deprecated=route.deprecated,
-                operation_id=route.operation_id,
-                responses=route.responses,
-            )(route.handler)
+            
 
     def add_middleware(self, middleware: MiddlewareType) -> None:
         """Add middleware to the router"""


### PR DESCRIPTION
- Remove APIDocumentation singleton implementation
- Delete get_instance() function
- Remove unused import of get_instance() in http.py
- Remove endpoint documentation from Router.add_route()