### PR TITLE
docs: update links and remove unused references

### DIFF
--- a/docs/docs/api-reference/channel.md
+++ b/docs/docs/api-reference/channel.md
@@ -366,6 +366,6 @@ print(repr(channel))
 
 ## 🔍 See Also
 
-- [WebSocket](./websocket.md) - WebSocket connection handling
-- [ChannelBox](./channelbox.md) - Channel group management  
-- [Consumer](./consumer.md) - WebSocket message consumers
+- [WebSocket](websocket.md) - WebSocket connection handling
+- [ChannelBox](channelbox.md) - Channel group management
+- [Consumer](consumer.md) - WebSocket message consumers

--- a/docs/docs/api-reference/channelbox.md
+++ b/docs/docs/api-reference/channelbox.md
@@ -517,6 +517,6 @@ export CHANNEL_BOX_HISTORY_SIZE=524288
 
 ## 🔍 See Also
 
-- [Channel](./channel.md) - Individual WebSocket channel management
-- [WebSocket](./websocket.md) - WebSocket connection handling
-- [Consumer](./consumer.md) - WebSocket message consumers
+- [Channel](channel.md) - Individual WebSocket channel management
+- [WebSocket](websocket.md) - WebSocket connection handling
+- [Consumer](consumer.md) - WebSocket message consumers

--- a/docs/docs/api-reference/depend.md
+++ b/docs/docs/api-reference/depend.md
@@ -622,8 +622,6 @@ async def list_users(request: Request, response: Response, service=Depend(get_us
 
 ## 🔍 See Also
 
-- [Context](./context.md) - Request context management
-- [Resolution](./resolution.md) - Dependency resolution process
-- [Middleware](../middleware/base.md) - Middleware system
-- [Testing](../testing/client.md) - Testing with dependencies
-- [Application](../application/nexios-app.md) - Application-level dependencies
+- [Middleware](./middleware.md) - Middleware system
+- [Testing](./testclient.md) - Testing with dependencies
+- [Application](./nexios-app.md) - Application-level dependencies

--- a/docs/docs/api-reference/group.md
+++ b/docs/docs/api-reference/group.md
@@ -365,7 +365,7 @@ print(f"Group name: {named_group.name}")  # "main_api"
 
 ## 🔍 See Also
 
-- [Router](./router.md) - Route organization and management
-- [Route](./route.md) - Individual route definitions
-- [Middleware](./middleware.md) - Request/response processing
-- [NexiosApp](./nexios-app.md) - Main application class
+- [Router](router.md) - Route organization and management
+- [Route](route.md) - Individual route definitions
+- [Middleware](middleware.md) - Request/response processing
+- [NexiosApp](nexios-app.md) - Main application class

--- a/docs/docs/api-reference/index.md
+++ b/docs/docs/api-reference/index.md
@@ -5,68 +5,44 @@ Welcome to the comprehensive Nexios API reference documentation. This section pr
 ## Core Components
 
 ### Application
-- [NexiosApp](./application/nexios-app.md) - Main application class
-- [Configuration](./application/configuration.md) - Application configuration system
-- [Lifecycle Management](./application/lifecycle.md) - Startup and shutdown handlers
+- [NexiosApp](./nexios-app.md) - Main application class
 
 ### HTTP Handling
-- [Request](./http/request.md) - HTTP request object and methods
-- [Response](./http/response.md) - HTTP response classes and utilities
-- [Cookies](./http/cookies.md) - Cookie handling and management
+- [Request](./request.md) - HTTP request object and methods
+- [Response](./response.md) - HTTP response classes and utilities
 
 ### Routing System
-- [Router](./routing/router.md) - Main routing class
-- [Route](./routing/route.md) - Individual route definitions
-- [Groups](./routing/groups.md) - Route grouping and organization
-- [URL Generation](./routing/url-generation.md) - URL building utilities
+- [Router](./router.md) - Main routing class
+- [Route](./route.md) - Individual route definitions
+- [Groups](./group.md) - Route grouping and organization
 
 ### Middleware
-- [Base Middleware](./middleware/base.md) - Middleware foundation
-- [CORS Middleware](./middleware/cors.md) - Cross-origin resource sharing
-- [CSRF Middleware](./middleware/csrf.md) - Cross-site request forgery protection
-- [Session Middleware](./middleware/session.md) - Session management
-- [Security Middleware](./middleware/security.md) - Security headers and protection
+- [Middleware](./middleware.md) - Middleware system and implementation
 
 ### Dependency Injection
-- [Depend](./dependencies/depend.md) - Dependency injection system
-- [Context](./dependencies/context.md) - Request context management
-- [Resolution](./dependencies/resolution.md) - Dependency resolution process
+- [Depend](./depend.md) - Dependency injection system
 
 ### WebSocket Support
-- [WebSocket](./websockets/websocket.md) - WebSocket connection handling
-- [WebSocket Router](./websockets/router.md) - WebSocket routing
-- [Channels](./websockets/channels.md) - WebSocket channel management
-
-### Authentication & Authorization
-- [Auth Base](./auth/base.md) - Authentication foundation
-- [User Models](./auth/users.md) - User management
-- [Auth Middleware](./auth/middleware.md) - Authentication middleware
-- [Backends](./auth/backends.md) - Authentication backends
+- [WebSocket](./websocket.md) - WebSocket connection handling
+- [Channel](./channel.md) - WebSocket channel management
+- [ChannelBox](./channelbox.md) - Channel boxing utilities
 
 ### OpenAPI Integration
-- [OpenAPI Builder](./openapi/builder.md) - OpenAPI documentation generation
-- [Models](./openapi/models.md) - OpenAPI model definitions
-- [Configuration](./openapi/config.md) - OpenAPI configuration options
+- [OpenAPI Builder](./openapi-builder.md) - OpenAPI documentation generation
 
 ### Testing
-- [Test Client](./testing/client.md) - Testing utilities
-- [Async Client](./testing/async-client.md) - Asynchronous testing
-- [Helpers](./testing/helpers.md) - Testing helper functions
-
-### Utilities
-- [Async Helpers](./utils/async-helpers.md) - Asynchronous utility functions
-- [Concurrency](./utils/concurrency.md) - Concurrency management
-- [Pydantic Integration](./utils/pydantic.md) - Pydantic model utilities
+- [Test Client](./testclient.md) - Testing utilities
 
 ## Quick Navigation
 
-- **Getting Started**: [Application Setup](./application/nexios-app.md)
-- **Request Handling**: [Request Object](./http/request.md) | [Response Object](./http/response.md)
-- **Routing**: [Router](./routing/router.md) | [Route Definitions](./routing/route.md)
-- **Middleware**: [Creating Middleware](./middleware/base.md)
-- **Dependencies**: [Dependency Injection](./dependencies/depend.md)
-- **WebSockets**: [WebSocket Handling](./websockets/websocket.md)
-- **Testing**: [Test Client](./testing/client.md)
+- **Getting Started**: [Application Setup](./nexios-app.md)
+- **Request Handling**: [Request Object](./request.md) | [Response Object](./response.md)
+- **Routing**: [Router](./router.md) | [Route Definitions](./route.md) | [Route Groups](./group.md)
+- **Middleware**: [Middleware System](./middleware.md)
+- **Dependencies**: [Dependency Injection](./depend.md)
+- **WebSockets**: [WebSocket Handling](./websocket.md) | [Channels](./channel.md) | [ChannelBox](./channelbox.md)
+- **Testing**: [Test Client](./testclient.md)
+- **OpenAPI**: [Documentation Builder](./openapi-builder.md)
 
 ## API Conventions
 

--- a/docs/docs/api-reference/middleware.md
+++ b/docs/docs/api-reference/middleware.md
@@ -613,9 +613,5 @@ class CompressionMiddleware(BaseMiddleware):
 
 ## 🔍 See Also
 
-- [CORS Middleware](./cors.md) - Cross-origin resource sharing
-- [CSRF Middleware](./csrf.md) - Cross-site request forgery protection
-- [Session Middleware](./session.md) - Session management
-- [Security Middleware](./security.md) - Security headers and protection
-- [Application](../application/nexios-app.md) - Application middleware setup
-- [Router](../routing/router.md) - Router-level middleware
+- [Application](./nexios-app.md) - Application middleware setup
+- [Router](./router.md) - Router-level middleware

--- a/docs/docs/api-reference/nexios-app.md
+++ b/docs/docs/api-reference/nexios-app.md
@@ -567,8 +567,7 @@ async def handle_websocket(self, scope: Scope, receive: Receive, send: Send) -> 
 
 ## 🔍 See Also
 
-- [Configuration](./configuration.md) - Application configuration system
-- [Router](../routing/router.md) - HTTP routing system
-- [Middleware](../middleware/base.md) - Middleware development
-- [Dependencies](../dependencies/depend.md) - Dependency injection system
-- [WebSocket](../websockets/websocket.md) - WebSocket handling
+- [Router](./router.md) - HTTP routing system
+- [Middleware](./middleware.md) - Middleware development
+- [Dependencies](./depend.md) - Dependency injection system
+- [WebSocket](./websocket.md) - WebSocket handling

--- a/docs/docs/api-reference/openapi-builder.md
+++ b/docs/docs/api-reference/openapi-builder.md
@@ -845,8 +845,5 @@ app.openapi_config.add_webhook("user_created", {
 
 ## 🔍 See Also
 
-- [OpenAPI Models](./models.md) - OpenAPI model definitions
-- [OpenAPI Configuration](./config.md) - Configuration options
-- [Application](../application/nexios-app.md) - Application setup
-- [Router](../routing/router.md) - Route documentation
-- [Authentication](../auth/base.md) - Security documentation
+- [Application](./nexios-app.md) - Application setup
+- [Router](./router.md) - Route documentation

--- a/docs/docs/api-reference/request.md
+++ b/docs/docs/api-reference/request.md
@@ -674,7 +674,4 @@ async def handler(request: Request, response: Response):
 ## 🔍 See Also
 
 - [Response](./response.md) - HTTP response handling
-- [Cookies](./cookies.md) - Cookie management
-- [Middleware](../middleware/base.md) - Request/response middleware
-- [Authentication](../auth/base.md) - Authentication system
-- [Session](../middleware/session.md) - Session management
+- [Middleware](./middleware.md) - Request/response middleware

--- a/docs/docs/api-reference/response.md
+++ b/docs/docs/api-reference/response.md
@@ -700,7 +700,5 @@ async def serve_file(request: Request, response: Response):
 ## 🔍 See Also
 
 - [Request](./request.md) - HTTP request handling
-- [Cookies](./cookies.md) - Cookie management details
-- [Middleware](../middleware/base.md) - Response middleware
-- [Caching](../middleware/security.md) - Caching strategies
-- [File Handling](../utils/async-helpers.md) - File utilities
+- [Middleware](./middleware.md) - Response middleware
+- [Testing](./testclient.md) - Testing utilities

--- a/docs/docs/api-reference/route.md
+++ b/docs/docs/api-reference/route.md
@@ -573,8 +573,7 @@ router.add_route(route)
 ## 🔍 See Also
 
 - [Router](./router.md) - Route organization and management
-- [Groups](./groups.md) - Route grouping strategies
-- [URL Generation](./url-generation.md) - Generating URLs from routes
-- [Middleware](../middleware/base.md) - Route middleware
-- [Dependencies](../dependencies/depend.md) - Route dependencies
-- [OpenAPI](../openapi/builder.md) - Route documentation
+- [Groups](./group.md) - Route grouping strategies
+- [Middleware](./middleware.md) - Route middleware
+- [Dependencies](./depend.md) - Route dependencies
+- [OpenAPI](./openapi-builder.md) - Route documentation

--- a/docs/docs/api-reference/router.md
+++ b/docs/docs/api-reference/router.md
@@ -727,8 +727,7 @@ print(len(router.middleware))  # 1
 ## 🔍 See Also
 
 - [Route](./route.md) - Individual route definitions
-- [Groups](./groups.md) - Route grouping and organization
-- [URL Generation](./url-generation.md) - URL building utilities
-- [Middleware](../middleware/base.md) - Middleware system
-- [Dependencies](../dependencies/depend.md) - Dependency injection
-- [OpenAPI](../openapi/builder.md) - API documentation
+- [Groups](./group.md) - Route grouping and organization
+- [Middleware](./middleware.md) - Middleware system
+- [Dependencies](./depend.md) - Dependency injection
+- [OpenAPI](./openapi-builder.md) - API documentation

--- a/docs/docs/api-reference/testclient.md
+++ b/docs/docs/api-reference/testclient.md
@@ -575,7 +575,6 @@ assert str(client.base_url) == "http://localhost:8000"
 
 ## 🔍 See Also
 
-- [NexiosApp](./nexios-app.md) - Main application class
 - [Request](./request.md) - HTTP request handling
 - [Response](./response.md) - HTTP response creation
 - [WebSocket](./websocket.md) - WebSocket connections

--- a/docs/docs/api-reference/websocket.md
+++ b/docs/docs/api-reference/websocket.md
@@ -793,8 +793,8 @@ async def queued_websocket_handler(websocket):
 
 ## 🔍 See Also
 
-- [WebSocket Router](./router.md) - WebSocket routing system
-- [Channels](./channels.md) - WebSocket channel management
-- [Middleware](../middleware/base.md) - WebSocket middleware
-- [Testing](../testing/client.md) - WebSocket testing utilities
+- [Router](./router.md) - WebSocket routing system
+- [Channel](./channel.md) - WebSocket channel management
+- [Middleware](./middleware.md) - WebSocket middleware
+- [Testing](./testclient.md) - WebSocket testing utilities
 - [Real-time Examples](../../examples/websockets.md) - WebSocket usage examples


### PR DESCRIPTION
- Remove relative path prefixes (./) from links
- Remove references to non-existent or moved files
- Consolidate and simplify "See Also" sections in multiple files
- Update file names to match current directory structure
- Remove duplicate entries and outdated references