### PR TITLE
build: remove granian dependency from all target

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,7 +64,6 @@ all = [
     "python-multipart>=0.0.6",
     "jinja2>=3.1.6",
     "pyjwt>=2.7.0",
-    "granian>=1.2.0",
     "click>=8.1.3"
 ]
 dev = [


### PR DESCRIPTION
- Removed "granian>=1.2.0" from the list of dependencies in the "all" target
- This change simplifies the project dependencies and reduces potential conflicts