### PR TITLE
fix(session): remove erroneous parameter overwrite in load_session_from_cookie

### DIFF
--- a/nexios/session/signed_cookies.py
+++ b/nexios/session/signed_cookies.py
@@ -48,8 +48,6 @@ class SignedSessionManager(BaseSessionInterface):
     def load_session_from_cookie(
         self, cookie: str
     ) -> typing.Optional[typing.Dict[str, typing.Any]]:
-        cookie = self.session_key
-
         """
         Load the session data from a signed cookie, and verify it.
         """
@@ -64,10 +62,10 @@ class SignedSessionManager(BaseSessionInterface):
         return signed_session
 
     async def load(self):
-        cookie = self.session_key
         """
         Load the session data from a signed cookie.
         """
+        cookie = self.session_key
         session_data = self.load_session_from_cookie(cookie)
 
         if session_data:


### PR DESCRIPTION
## Summary
Fix a critical bug in `SignedSessionManager.load_session_from_cookie()` where the `cookie` parameter was immediately overwritten with `self.session_key`, making the parameter useless.

## Problem
In `nexios/session/signed_cookies.py`, line 51:
```python
def load_session_from_cookie(
    self, cookie: str
) -> typing.Optional[typing.Dict[str, typing.Any]]:
    cookie = self.session_key  # BUG: Parameter is overwritten!
    ...
    return self.verify_session_data(cookie)
```

The `cookie` parameter was immediately replaced with `self.session_key`, so the actual cookie value passed to the function was never used.

## Impact
- Session data from cookies could not be loaded correctly
- The function always verified `self.session_key` instead of the provided cookie
- Could cause session authentication issues

## Solution
Removed the erroneous line `cookie = self.session_key` and moved docstrings to proper position.

## Testing
The fix is straightforward - removing the incorrect line restores expected behavior where the provided cookie parameter is used for verification.