### PR TITLE
feat(env): read .env in the framework, and drop python-dotenv

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
 # ==============================
 #  Environment & Configuration
 # ==============================
-env/
+
 .vscode/
 .env
 poetry.lock

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,45 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Sillo reads `.env` itself.** `sillo.env` is a `.env` parser written for
+  the framework: `python-dotenv` is not a dependency, is not installed as
+  one, and is not imported anywhere. The file supports quoting, escapes,
+  multi-line triple-quoted values (certificates and private keys), `export`
+  prefixes, inline comments, and `${REFERENCES}` with `${NAME:-fallback}`
+  defaults resolved against the file first and the surrounding environment
+  second.
+
+- **`.env` is loaded without being asked for.** `SilloApp(...)`, any
+  `sillo.config.Config` subclass, and the `sillo` command each load the
+  project's `.env` once per process. The file is found by searching upward
+  from the working directory and stopping at the project root, so a command
+  run from a subdirectory finds it and a `.env` in a home directory never
+  leaks in. Variables already exported win over the file; set
+  `SILLO_ENV_FILE` to name another file, or to the empty string to switch
+  automatic loading off.
+
+- **`sillo.env` public functions**: `load_env`, `find_env`, `parse_env` and
+  `env` — the last a typed single-variable read, where `cast=bool`
+  understands `true/yes/on/1` rather than Python's "any non-empty string".
+
+- **`Config` supports `env_prefix`**, so one `.env` can hold several
+  subsystems (`DATABASE_URL`, `DATABASE_POOL_SIZE`) without the field names
+  carrying the prefix. A field's Pydantic `alias` now also names the
+  environment variable it reads.
+
+- **`Config` options belong in an inner `Env` class.** An inner class named
+  `Config` still works, but Pydantic claims that name for its own deprecated
+  class-based settings and warns on every model that uses one.
+
+### Fixed
+
+- **`print(config)` no longer prints secrets.** `Config.__repr__` masked
+  fields whose names look like secrets, but `print()` calls `__str__`, which
+  Pydantic writes out in full. Both are masked now.
+
+
 ## [0.1.0] - 2026-08-17
 
 The first stable release. The API surface is now covered by semantic

--- a/docs/docs/astro.config.mjs
+++ b/docs/docs/astro.config.mjs
@@ -418,6 +418,7 @@ export default defineConfig({
                         { label: 'Introduction', link: '/guides/introduction/' },
                         { label: 'Installation', link: '/guides/installation/' },
                         { label: 'Configuration', link: '/guides/configuration/' },
+                        { label: 'Environment & .env', link: '/guides/environment/' },
                         { label: 'Request Lifecycle', link: '/guides/request-lifecycle/' },
                     ],
                 },

--- a/docs/docs/src/content/docs/advanced/configuration.md
+++ b/docs/docs/src/content/docs/advanced/configuration.md
@@ -11,27 +11,37 @@ description: "Config class, .env loading, secret masking, environment variables"
 `BaseModel` with automatic `.env` file loading, environment variable mapping,
 and secret masking in `repr` output.
 
+The `.env` reading is Sillo's own — `sillo.env`, documented in
+[Environment & .env](/guides/environment/). `python-dotenv` is not a
+dependency of the framework and is not imported anywhere in it.
+
 ### Class Definition
 
 ```python
 class Config(BaseModel):
-    """Base configuration class with .env file support."""
+    """Base configuration class, loaded from the environment."""
 
     model_config = ConfigDict(extra="ignore")
 
     def __init__(
         self,
-        _env_file: str | None = None,
-        _case_sensitive: bool = False,
+        _env_file: str | None = _UNSET,
+        _case_sensitive: bool = _UNSET,
+        _env_prefix: str = _UNSET,
         **data
     ):
 ```
+
+`_UNSET` is a sentinel, not a default value: it separates "the subclass said
+nothing", which loads the project's `.env`, from an explicit `None`, which
+loads no file at all.
 
 ### Features
 
 | Feature | Description |
 |---------|-------------|
-| `.env` loading | Automatically loads environment variables from a `.env` file via `python-dotenv` |
+| `.env` loading | Finds and loads the project's `.env` through `sillo.env.autoload`, once per process. No third-party dependency |
+| Env prefix | `env_prefix` maps a whole class onto `PREFIX_*` variables |
 | Type validation | All fields are validated by Pydantic at construction time |
 | Env var mapping | Field names are mapped to uppercase environment variables by default |
 | Secret masking | Fields with names containing `secret`, `key`, `password`, `token`, etc. are masked in `repr()` |
@@ -41,29 +51,41 @@ class Config(BaseModel):
 ### Initialization Flow
 
 ```python
-def __init__(self, _env_file=None, _case_sensitive=False, **data):
-    # 1. Check subclass for env_file and case_sensitive config
-    config_dict = getattr(self.__class__.Config, "__dict__", {}) if hasattr(self.__class__, "Config") else {}
-    env_file = _env_file or config_dict.get("env_file")
-    case_sensitive = _case_sensitive or config_dict.get("case_sensitive", False)
+def __init__(self, _env_file=_UNSET, _case_sensitive=_UNSET, _env_prefix=_UNSET, **data):
+    # 1. Read the subclass's inner options class (Env, or the older Config)
+    options = self._options()
+    env_file = _env_file if _env_file is not _UNSET else options.get("env_file", _UNSET)
+    case_sensitive = ...
+    prefix = ...
 
-    # 2. Load .env file if specified
-    if env_file:
-        from dotenv import load_dotenv
-        load_dotenv(env_file)
+    # 2. Load the file: the project's .env when nothing was asked for,
+    #    the named file when one was, nothing at all when it is None.
+    if env_file is _UNSET:
+        autoload()
+    elif env_file is not None:
+        load_env(env_file)
 
-    # 3. Load from environment variables
-    import os
+    # 3. Map fields onto environment variables, alias first
     env_data = {}
-    for field_name in self.__class__.model_fields:
-        env_key = field_name if case_sensitive else field_name.upper()
-        if env_key in os.environ:
-            env_data[field_name] = os.environ[env_key]
+    for name, field in self.__class__.model_fields.items():
+        alias = field.alias if isinstance(field.alias, str) else None
+        for candidate in (alias, name):
+            if candidate is None:
+                continue
+            key = prefix + candidate
+            if not case_sensitive:
+                key = key.upper()
+            if key in os.environ:
+                env_data[alias or name] = os.environ[key]
+                break
 
     # 4. Merge with provided data (provided data takes precedence)
     env_data.update(data)
     super().__init__(**env_data)
 ```
+
+Three sources, most specific first: arguments beat the real environment, and
+the real environment beats the file.
 
 ### Environment Variable Mapping
 
@@ -118,23 +140,27 @@ print(repr(config))
 # <AppConfig {'database_url': 'postgres://localhost/mydb', 'jwt_secret': '***', 'api_key': '***'}>
 ```
 
-### Subclass Config Inner Class
+### Subclass Options Inner Class
 
 ```python
 class AppConfig(Config):
     database_url: str
     debug: bool = False
 
-    class Config:
-        env_file = ".env"
+    class Env:
+        env_file = ".env"          # None loads no file
+        env_prefix = ""
         case_sensitive = False
 ```
 
-The inner `Config` class is checked for `env_file` and `case_sensitive` settings.
-These can also be overridden at instantiation time:
+`Env` is checked first, then `Config` — the name earlier versions documented,
+kept working but no longer recommended, since Pydantic uses it for its own
+deprecated class-based settings and warns whenever it sees one.
+
+Each setting can be overridden at instantiation time:
 
 ```python
-config = AppConfig(_env_file=".env.production", _case_sensitive=True)
+config = AppConfig(_env_file=".env.production", _case_sensitive=True, _env_prefix="APP_")
 ```
 
 ### Re-exported Field
@@ -186,9 +212,8 @@ class DatabaseConfig(Config):
     # Migration
     migration_dir: str = Field(default="migrations", description="Migration scripts directory")
 
-    class Config:
-        env_file = ".env"
-        case_sensitive = False
+    class Env:
+        env_prefix = "DATABASE_"
 ```
 
 ### Environment Variable Mapping
@@ -242,8 +267,8 @@ class SessionConfig(Config):
     # Database settings (when driver="database")
     table_name: str = Field(default="sessions", description="Sessions table name")
 
-    class Config:
-        env_file = ".env"
+    class Env:
+        env_prefix = "SESSION_"
 ```
 
 ### Environment Variable Mapping
@@ -284,8 +309,8 @@ class MailConfig(Config):
     retry_count: int = Field(default=3, description="Retry count for failed sends")
     retry_delay: int = Field(default=60, description="Retry delay in seconds")
 
-    class Config:
-        env_file = ".env"
+    class Env:
+        env_prefix = "MAIL_"
 ```
 
 ### Environment Variable Mapping
@@ -334,8 +359,8 @@ class CorsConfig(Config):
         description="Preflight cache duration in seconds"
     )
 
-    class Config:
-        env_file = ".env"
+    class Env:
+        env_prefix = "CORS_"
 ```
 
 ### Environment Variable Mapping
@@ -395,8 +420,8 @@ class CSRFConfig(Config):
         description="Paths exempt from CSRF checks"
     )
 
-    class Config:
-        env_file = ".env"
+    class Env:
+        env_prefix = "CSRF_"
 ```
 
 ### Environment Variable Mapping
@@ -447,8 +472,8 @@ class RateLimitConfig(Config):
         description="Error message for rate limited requests"
     )
 
-    class Config:
-        env_file = ".env"
+    class Env:
+        env_prefix = "RATE_LIMIT_"
 ```
 
 ### Environment Variable Mapping
@@ -512,8 +537,8 @@ class TemplateConfig(Config):
         description="Global variables available in all templates"
     )
 
-    class Config:
-        env_file = ".env"
+    class Env:
+        env_prefix = "TEMPLATE_"
 ```
 
 ### Environment Variable Mapping
@@ -580,8 +605,8 @@ class InertiaConfig(Config):
         description="Enable Inertia testing helpers"
     )
 
-    class Config:
-        env_file = ".env"
+    class Env:
+        env_prefix = "INERTIA_"
 ```
 
 ### Environment Variable Mapping
@@ -630,9 +655,8 @@ class AppConfig(Config):
     # Subsystem configs are declared as fields
     # They can be nested or flattened depending on preference
 
-    class Config:
+    class Env:
         env_file = ".env"
-        case_sensitive = False
 
 # Flat approach (all vars at top level)
 class FlatAppConfig(Config):

--- a/docs/docs/src/content/docs/guides/configuration.md
+++ b/docs/docs/src/content/docs/guides/configuration.md
@@ -3,7 +3,8 @@ title: Configuration Management
 description: Type-safe configuration with Pydantic and environment variables
 ---
 
-Sillo provides type-safe configuration management using Pydantic, with automatic .env file loading, validation, and environment-specific settings.
+Sillo provides type-safe configuration management using Pydantic, with `.env`
+loading, validation, and environment-specific settings.
 
 ## Overview
 
@@ -19,12 +20,11 @@ The configuration system provides:
 
 ## Installation
 
-Configuration support is built-in. Just create a config class and .env file:
-
-```bash
-# No additional packages needed
-# Uses Pydantic (already a dependency)
-```
+Nothing to install. Sillo parses `.env` itself — `python-dotenv` is not a
+dependency, and there is no `load_dotenv()` call to remember. Constructing a
+config, or a `SilloApp`, loads the project's `.env` on its own. See
+[Environment & .env](/guides/environment/) for the file format and the
+precedence rules.
 
 ## Quick Start
 
@@ -45,12 +45,8 @@ class AppConfig(Config):
     debug: bool = False
     log_level: Literal['debug', 'info', 'warning', 'error'] = 'info'
     port: int = 8000
-    
-    class Config:
-        env_file = '.env'
-        case_sensitive = False
 
-# Load configuration
+# Load configuration — .env is found and read automatically
 config = AppConfig()
 ```
 
@@ -109,12 +105,32 @@ class AppConfig(Config):
     
     # Optional (can be None)
     cache_url: Optional[str] = None
-    
-    class Config:
-        env_file = '.env'
-        env_file_encoding = 'utf-8'
-        case_sensitive = False
 ```
+
+### Adjusting the Defaults
+
+An inner `Env` class changes how the fields map onto the environment. Every
+setting is optional:
+
+```python
+class DatabaseConfig(Config):
+    url: str
+    pool_size: int = 10
+
+    class Env:
+        env_file = '.env.production'   # None loads no file at all
+        env_prefix = 'DATABASE_'       # DATABASE_URL, DATABASE_POOL_SIZE
+        case_sensitive = False         # the default: field names uppercased
+```
+
+`env_prefix` is what lets one `.env` serve several subsystems without the
+field names growing prefixes of their own.
+
+:::note
+An inner class named `Config` is read the same way — that is what earlier
+versions documented. Prefer `Env`: Pydantic claims the name `Config` for its
+own deprecated class-based settings and warns on every model that uses one.
+:::
 
 ### Type Support
 
@@ -159,11 +175,12 @@ timeout: float = 30.0   # Must be float
 # These work:
 PORT=8000           # Loaded as int
 DEBUG=true          # Converted to bool
+DEBUG=yes           # So are yes/no, on/off and 1/0
 TIMEOUT=30.5        # Loaded as float
 
 # These fail:
 PORT=eight          # ValidationError
-DEBUG=yes           # ValidationError (only true/false works)
+DEBUG=maybe         # ValidationError
 ```
 
 ## .env Files
@@ -176,19 +193,30 @@ DATABASE_URL=postgresql://localhost/db
 DEBUG=true
 PORT=8000
 
-# Multiline not directly supported, use single line
-LONG_VALUE=this_is_a_long_value_on_a_single_line
+# Spaces around = are fine
+KEY = value
+
+# Quotes keep whitespace; single quotes stop all expansion
+QUOTED="  spaces kept  "
+LITERAL='nothing $expands here'
+
+# Multi-line values, for keys and certificates
+PRIVATE_KEY="""-----BEGIN PRIVATE KEY-----
+MIIEvQIBADANBgkq...
+-----END PRIVATE KEY-----"""
+
+# References to earlier keys, and to the surrounding environment
+DB_HOST=db.internal
+DATABASE_URL=postgres://${DB_HOST}:5432/app
+PORT=${PORT:-8000}
 
 # Comments with #
 # This is a comment
-SECRET_KEY=...  # Inline comment
-
-# Empty lines are OK
-
-# No spaces around = (recommended)
-KEY=value        # OK
-KEY = value      # Also OK
+SECRET_KEY=abc123  # Inline comment — the space before # is what makes it one
+PASSWORD=pa#ssword # No space, so this hash is part of the password
 ```
+
+The full grammar is in [Environment & .env](/guides/environment/).
 
 ### File Locations
 
@@ -203,15 +231,31 @@ project/
 
 ### Environment-Specific Loading
 
+The usual way is from the outside, so the code does not have to know:
+
+```bash
+SILLO_ENV_FILE=.env.production sillo serve
+```
+
+Or decide in code:
+
 ```python
 import os
 
-environment = os.getenv('ENVIRONMENT', 'development')
-env_file = f'.env.{environment}'
-
 class AppConfig(Config):
-    class Config:
-        env_file = env_file  # Load .env.development or .env.production
+    database_url: str
+
+    class Env:
+        env_file = f".env.{os.getenv('ENVIRONMENT', 'development')}"
+```
+
+To layer a developer's overrides on top of a shared file:
+
+```python
+from sillo.env import load_env
+
+load_env()                              # .env
+load_env('.env.local', override=True)   # then whatever this machine changes
 ```
 
 ## Usage Patterns
@@ -609,20 +653,35 @@ PORT=8000   # Right
 
 ### Config not loading from .env
 
-**Problem:** File not found or wrong path
+**Problem:** The file is not where the search looks, or the variable is
+already set in the real environment (which wins).
+
+Check what the search finds, and what the file actually parses to:
 
 ```python
-class Config(Config):
-    class Config:
-        env_file = '.env'  # Must be in current directory
+from sillo.env import find_env, parse_env
 
-# OR with full path
+print(find_env())                     # the file being used, or None
+print(parse_env(open('.env').read())) # what it parses to
+```
+
+The search runs upward from the working directory and stops at the project
+root, so a `.env` above the project is deliberately ignored. Name the file
+outright when it lives somewhere else:
+
+```python
 from pathlib import Path
 
-class Config(Config):
-    class Config:
+class AppConfig(Config):
+    database_url: str
+
+    class Env:
         env_file = str(Path(__file__).parent / '.env')
 ```
+
+If the value is stale rather than missing, something exported it before the
+process started — `echo $DATABASE_URL` — and the real environment beats the
+file by design. Use `load_env(..., override=True)` to reverse that.
 
 ### Secrets appear in logs
 
@@ -640,7 +699,7 @@ access_token: str     # Appears as ***
 
 ## See Also
 
-- [Environment Variables](/guides/request-info) - Request environment access
+- [Environment & .env](/guides/environment/) - The file format, precedence, and `sillo.env`
 - [Security](/guides/security) - Security best practices
 - [Deployment](/guides/start/deployment/) - Deployment configuration
 - [Pydantic Docs](https://docs.pydantic.dev/) - Full Pydantic reference

--- a/docs/docs/src/content/docs/guides/environment.md
+++ b/docs/docs/src/content/docs/guides/environment.md
@@ -1,0 +1,202 @@
+---
+title: Environment & .env
+description: How Sillo reads .env files, with no python-dotenv and no setup
+---
+
+Sillo reads `.env` itself. There is no `python-dotenv` to install, no
+`load_dotenv()` to remember to call, and no import order to get right.
+
+Write a `.env`:
+
+```bash
+DATABASE_URL=postgresql://localhost/mydb
+JWT_SECRET=dev-secret
+DEBUG=true
+```
+
+Then read it:
+
+```python
+from sillo import SilloApp
+from sillo.config import Config
+
+class Settings(Config):
+    database_url: str
+    jwt_secret: str
+    debug: bool = False
+
+settings = Settings()      # .env has already been read
+app = SilloApp(debug=settings.debug)
+```
+
+## When the file is read
+
+Both `SilloApp(...)` and any `Config` subclass load the project's `.env` on
+construction, once per process. The `sillo` command loads it earlier still —
+before your application module is imported — so a module that reads
+`os.environ` at import time sees the file's values too.
+
+The file is found by searching upward from the working directory, stopping at
+the project root (the first directory holding `pyproject.toml`, `uv.lock`,
+`setup.py`, `setup.cfg` or `.git`). Running `sillo serve` from
+`myproject/app/handlers` finds `myproject/.env`; a stray `.env` in your home
+directory is never picked up.
+
+## Precedence
+
+Three sources, most specific first:
+
+1. **Arguments** — `Settings(database_url="sqlite://:memory:")`
+2. **The real environment** — what the shell, container or platform exported
+3. **`.env`** — the file
+
+A variable already exported wins over the file. That is what makes the same
+image work in every environment: the `.env` baked in during development is
+still there, and production's exported `DATABASE_URL` overrules it.
+
+To go the other way, load with `override=True`:
+
+```python
+from sillo.env import load_env
+
+load_env(".env.local", override=True)   # the file wins this time
+```
+
+## The file format
+
+```bash
+# A comment. Blank lines are fine too.
+
+DATABASE_URL=postgresql://localhost/mydb    # a trailing comment
+export API_KEY=abc123                        # `export` is allowed and ignored
+
+QUOTED="spaces   are kept"
+LITERAL='nothing $expands in here'
+ESCAPED="line one\nline two"
+
+PRIVATE_KEY="""-----BEGIN PRIVATE KEY-----
+MIIEvQIBADANBgkq...
+-----END PRIVATE KEY-----"""
+
+DB_HOST=db.internal
+DATABASE_URL=postgres://${DB_HOST}:5432/app
+PORT=${PORT:-8000}
+PASSWORD=pa\$\$word
+```
+
+| Form | Meaning |
+|------|---------|
+| `KEY=value` | Everything to the end of the line, trimmed |
+| `KEY="value"` | Escapes (`\n`, `\t`, `\"`) and `${REFERENCES}` are resolved |
+| `KEY='value'` | Taken literally — nothing is expanded or unescaped |
+| `KEY="""…"""` | Multi-line, resolved like a double-quoted value |
+| `KEY='''…'''` | Multi-line, literal |
+| `export KEY=value` | The prefix is dropped |
+| `# comment` | Skipped |
+| `KEY=value # note` | The comment is dropped — the space before `#` is required |
+
+Two details that bite people elsewhere:
+
+- `PASSWORD=pa#ssword` keeps its `#`. A hash only starts a comment when
+  whitespace comes before it.
+- `PASSWORD=pa$$word` would expand. Write `pa\$\$word`, or single-quote the
+  value, to keep the dollars.
+
+### References
+
+`${NAME}` and `$NAME` resolve against names defined earlier in the same file
+first, then against the surrounding environment. A name that resolves nowhere
+becomes the empty string.
+
+| Form | Result |
+|------|--------|
+| `${NAME}` | The value, or empty |
+| `${NAME:-fallback}` | `fallback` when `NAME` is unset **or empty** |
+| `${NAME-fallback}` | `fallback` only when `NAME` is unset |
+| `\$NAME` | A literal `$NAME` |
+
+## Choosing a different file
+
+Point `SILLO_ENV_FILE` at another path, and everything that loads
+automatically loads that instead:
+
+```bash
+SILLO_ENV_FILE=.env.production sillo serve
+```
+
+Set it to the empty string to turn automatic loading off — useful in tests,
+where the environment should be the only source of truth:
+
+```bash
+SILLO_ENV_FILE= pytest
+```
+
+A single config class can name its own file:
+
+```python
+class Settings(Config):
+    database_url: str
+
+    class Env:
+        env_file = ".env.production"   # or None, to load no file at all
+```
+
+## Layering files
+
+There is no implicit `.env.local`. Two calls, in the order you want them:
+
+```python
+from sillo.env import load_env
+
+load_env()                              # .env
+load_env(".env.local", override=True)   # whatever the developer changed
+```
+
+## Reading one variable
+
+Not everything deserves a config class. `env()` reads a single variable with
+a type:
+
+```python
+from sillo.env import env
+
+port = env("PORT", 8000, cast=int)
+debug = env("DEBUG", False, cast=bool)
+hosts = env("ALLOWED_HOSTS", "localhost", cast=lambda raw: raw.split(","))
+secret = env("JWT_SECRET")     # no default: raises KeyError if unset
+```
+
+`cast=bool` understands what `.env` files actually contain — `true`, `yes`,
+`on`, `1` and their opposites — rather than Python's rule where the string
+`"false"` is true.
+
+## The API
+
+Everything lives in `sillo.env`:
+
+| Function | Does |
+|----------|------|
+| `load_env(path=None, *, override=False, search=True)` | Reads a file into `os.environ`, returns what it applied |
+| `find_env(name=".env", start=None)` | The upward search, on its own |
+| `parse_env(text)` | Parses text to a dict, touching nothing |
+| `env(key, default, *, cast=None)` | One typed read |
+| `autoload()` | What the framework calls: find, load, remember |
+
+A missing file is never an error. Most deployments have no `.env` at all —
+the platform exports the variables — and an application should start anyway.
+
+## Docker and deploys
+
+Do not ship `.env` in the image. Export the variables instead:
+
+```bash
+docker run -e DATABASE_URL=postgres://... -e JWT_SECRET=... myapp
+```
+
+They win over any `.env` that ends up in the image regardless, but a secret
+that is not in the image cannot leak from it.
+
+## See Also
+
+- [Configuration Management](/guides/configuration/) — config classes, validation, secret masking
+- [Secrets & .env](/start/secrets/) — what `sillo-start` generates

--- a/docs/docs/src/content/docs/start/secrets.md
+++ b/docs/docs/src/content/docs/start/secrets.md
@@ -116,5 +116,7 @@ project can decide what a good value looks like.
 ## See also
 
 - [Configuration](/guides/configuration/): how the application reads these.
+- [Environment & .env](/guides/environment/): the file format, and when sillo
+  reads it.
 - [Personalisation](/start/personalisation/): the other half of what happens
   after a fetch.

--- a/examples/config/.env.example
+++ b/examples/config/.env.example
@@ -1,3 +1,10 @@
+# Copy to .env and edit. Sillo reads this file itself — nothing to install.
+#
+#   cp .env.example .env
+#
+# A variable already exported in the real environment wins over this file,
+# so the same image works in development and in production.
+
 # Application Settings
 APP_NAME=My API
 ENVIRONMENT=development
@@ -5,11 +12,14 @@ DEBUG=true
 LOG_LEVEL=info
 PORT=8000
 
-# Database Configuration
+# Database
+# ${...} refers to a name defined above, or to the surrounding environment.
+DB_HOST=localhost
 DATABASE_URL=sqlite:///dev.db
 DATABASE_POOL_SIZE=10
 
 # Security (JWT)
+# Quote a value to keep its spaces; single-quote it to keep a literal $.
 JWT_SECRET=your-secret-key-here
 JWT_ALGORITHM=HS256
 JWT_EXPIRATION_HOURS=24
@@ -18,3 +28,8 @@ JWT_EXPIRATION_HOURS=24
 ENABLE_SWAGGER=true
 ENABLE_CORS=true
 CORS_ORIGINS=*
+
+# Multi-line values need triple quotes:
+# PRIVATE_KEY="""-----BEGIN PRIVATE KEY-----
+# MIIEvQIBADANBgkq...
+# -----END PRIVATE KEY-----"""

--- a/examples/config/01_basic_config.py
+++ b/examples/config/01_basic_config.py
@@ -1,11 +1,19 @@
 """Basic configuration example.
 
+A config class reads the project's .env on its own — sillo parses .env
+itself, so there is no python-dotenv to install and no load_dotenv() to
+call. This example names its file only because the file sits beside the
+script rather than at the project root, where it would be found without
+being named.
+
 Run with:
     uv run python examples/config/01_basic_config.py
 """
 
-from sillo.config import Config, Field
+from pathlib import Path
 from typing import Literal
+
+from sillo.config import Config
 
 
 class AppConfig(Config):
@@ -21,15 +29,16 @@ class AppConfig(Config):
     port: int = 8000
     host: str = '127.0.0.1'
 
-    class Config:
-        env_file = '.env'
-        case_sensitive = False
+    class Env:
+        # Left out, the project's .env is found by searching upward from
+        # the working directory.
+        env_file = str(Path(__file__).parent / '.env.development')
 
 
 def main():
     """Demonstrate basic config usage."""
 
-    # Load config from .env
+    # Load config from the .env file
     config = AppConfig()
 
     print("Configuration loaded successfully!")

--- a/examples/config/02_web_app.py
+++ b/examples/config/02_web_app.py
@@ -4,10 +4,12 @@ Run with:
     uv run uvicorn examples/config/02_web_app:app --reload
 """
 
-from sillo import SilloApp, Query
+from pathlib import Path
+from typing import Literal, Optional
+
+from sillo import Query, SilloApp
 from sillo.config import Config, Field
 from sillo.core.http import Request, Response
-from typing import Literal, Optional
 
 
 class AppConfig(Config):
@@ -39,9 +41,10 @@ class AppConfig(Config):
     enable_cors: bool = True
     cors_origins: str = '*'
 
-    class Config:
-        env_file = '.env'
-        case_sensitive = False
+    class Env:
+        # A project keeps .env at its root, where it is found without being
+        # named. This example's file sits beside the script.
+        env_file = str(Path(__file__).parent / '.env.development')
 
 
 # Load config

--- a/examples/config/README.md
+++ b/examples/config/README.md
@@ -10,7 +10,7 @@ Sillo's configuration system provides:
 - **Validation** - Pydantic validates all values on load
 - **Environment-specific** - Different configs per environment
 - **Secret masking** - Automatically hides secrets in repr
-- **.env file support** - Load from `.env` files
+- **.env file support** - Read by sillo itself; `python-dotenv` is not needed
 - **Required vs optional** - Clear which fields are required
 - **Smart defaults** - Default values for optional fields
 
@@ -31,12 +31,8 @@ class AppConfig(Config):
     debug: bool = False
     log_level: Literal['debug', 'info', 'warning', 'error'] = 'info'
     port: int = 8000
-    
-    class Config:
-        env_file = '.env'
-        case_sensitive = False
 
-config = AppConfig()
+config = AppConfig()   # .env is found and read automatically
 ```
 
 ### 2. Create .env File
@@ -137,12 +133,23 @@ Use `Field()` to map environment variables:
 ```python
 from sillo.config import Config, Field
 
-class Config(Config):
-    # Map different env var name
-    database_url: str = Field(..., alias='DB_URL')
-    
+class AppConfig(Config):
+    # Reads DB_URL instead of DATABASE_URL
+    database_url: str = Field(..., alias='db_url')
+
     # Custom description for validation errors
     port: int = Field(default=8000, description='Server port')
+```
+
+Or prefix a whole class, so one .env can hold several subsystems:
+
+```python
+class DatabaseConfig(Config):
+    url: str              # DATABASE_URL
+    pool_size: int = 10   # DATABASE_POOL_SIZE
+
+    class Env:
+        env_prefix = 'DATABASE_'
 ```
 
 ## Environment-Specific Configs
@@ -288,15 +295,22 @@ class Config(Config):
 
 ### Multi-Environment Setup
 
+From the outside, so the code does not have to know:
+
+```bash
+SILLO_ENV_FILE=.env.production uv run uvicorn app:app
+```
+
+Or in the class:
+
 ```python
 import os
 
-environment = os.getenv('ENVIRONMENT', 'development')
-env_file = f'.env.{environment}'
+class AppConfig(Config):
+    database_url: str
 
-class Config(Config):
-    class Config:
-        env_file = env_file
+    class Env:
+        env_file = f".env.{os.getenv('ENVIRONMENT', 'development')}"
 ```
 
 ## Troubleshooting
@@ -347,7 +361,7 @@ database_password: str  # Appears as *** in repr
 
 ## See Also
 
-- [Environment Variables Guide](#) - .env file format
+- [Environment & .env](https://docs.sillo.build/guides/environment/) - .env file format, precedence, `sillo.env`
 - [Pydantic Documentation](https://docs.pydantic.dev/) - Full Pydantic reference
 - [Sillo Authentication](/guides/authentication) - Using config for auth
 - [Sillo Users](/guides/users) - Integrating with user system

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,7 +66,6 @@ dependencies = [
     "python-multipart>=0.0.6",
     "pydantic>=2.0,<3.0",
     "typing-extensions>=4.12.2; python_version<'3.10'",
-    "python-dotenv>=1.0.0",
 ]
 
 # CORE: Only includes what's required for any sillo app (HTTP routing, config, password hashing)

--- a/sillo/__main__.py
+++ b/sillo/__main__.py
@@ -30,6 +30,8 @@ import sys
 from pathlib import Path
 from typing import Any, ClassVar
 
+from sillo.env import autoload
+
 from .console import Argument, Command, Console, Flag, Option
 
 __all__ = ["build_console", "discover_application", "main"]
@@ -492,6 +494,10 @@ def build_console() -> tuple[Console, str | None]:
         but could not be used.
     """
     import sillo
+
+    # Before the project is imported, so a module that reads os.environ at
+    # import time sees what .env says. Nothing has to install python-dotenv.
+    autoload()
 
     console = Console(
         prog="sillo",

--- a/sillo/application.py
+++ b/sillo/application.py
@@ -28,6 +28,7 @@ from sillo.core.error import (
 from sillo.core.helpers.async_helpers import is_async_callable
 from sillo.core.routing import Route, Router, WebsocketRoute
 from sillo.core.routing.base import BaseRoute
+from sillo.env import autoload as _autoload_env
 from sillo.events import EventEmitter
 from sillo.exception_handler import ExceptionMiddleware
 from sillo.logging import create_logger
@@ -343,6 +344,11 @@ class SilloApp:
                 thing two ways.
             ValueError: If two documentation viewers claim the same path.
         """
+        # The project's .env, read once per process. An application that
+        # reads os.environ at import time has it already, and no project
+        # needs python-dotenv to make that true. SILLO_ENV_FILE="" opts out.
+        _autoload_env()
+
         # Assigned directly: the property setter rebuilds the chain, which
         # cannot happen before the rest of __init__ has run. The chain is
         # built once at the end, when everything it needs exists.

--- a/sillo/config/core.py
+++ b/sillo/config/core.py
@@ -2,42 +2,88 @@
 
 from __future__ import annotations
 
+import os
+from typing import Any
+
 from pydantic import BaseModel, ConfigDict
 from pydantic import Field as PydanticField
 
+from sillo.env import autoload, load_env
+
+__all__ = ["Config", "Field"]
+
+#: Tells "the subclass said nothing" apart from "the subclass said ``None``",
+#: which is how a project turns .env loading off.
+_UNSET: Any = object()
+
+#: A field whose name contains one of these is masked in ``repr``.
+SECRET_KEYWORDS = (
+    "secret",
+    "key",
+    "password",
+    "token",
+    "apikey",
+    "api_key",
+    "auth",
+    "credential",
+    "private",
+)
+
 
 class Config(BaseModel):
-    """Base configuration class with .env file support.
+    """Base configuration class, loaded from the environment.
 
-    Extends Pydantic's BaseModel to provide:
-    - Automatic .env file loading (via python-dotenv)
-    - Type validation
-    - Environment variable mapping
-    - IDE autocomplete
-    - Clear required vs optional fields
+    Extends Pydantic's ``BaseModel`` with:
 
-    Example:
+    - the project's ``.env`` file, read by sillo itself — ``python-dotenv``
+      is not a dependency and is not needed
+    - environment variables mapped onto fields
+    - type validation, and the IDE autocomplete that comes with it
+    - secrets masked in ``repr``
 
-        from sillo.config import Config, Field
-        from typing import Literal
+    Nothing has to be configured. Constructing a config loads ``.env`` from
+    the project (searching upward from the working directory, stopping at the
+    project root) if one is there::
+
+        from sillo.config import Config
 
         class AppConfig(Config):
-            # Required fields
+            # Required: no default, so a missing DATABASE_URL is an error
+            # at startup rather than a None at midnight.
             database_url: str
             jwt_secret: str
 
-            # Optional fields with defaults
+            # Optional, with defaults
             debug: bool = False
             log_level: Literal['debug', 'info', 'warning', 'error'] = 'info'
             port: int = 8000
 
-            class Config:
-                env_file = '.env'
+        config = AppConfig()
+        config.database_url    # str, validated
+        config.port            # int, converted from the string in .env
+
+    Values already exported in the real environment win over the file, so a
+    deployment's ``DATABASE_URL`` beats a ``.env`` that shipped in the image.
+    Values passed to the constructor win over both.
+
+    An inner ``Env`` class adjusts the defaults::
+
+        class DatabaseConfig(Config):
+            url: str
+            pool_size: int = 10
+
+            class Env:
+                env_file = ".env.production"   # None to load no file at all
+                env_prefix = "DATABASE_"       # DATABASE_URL, DATABASE_POOL_SIZE
                 case_sensitive = False
 
-        config = AppConfig()
-        print(config.database_url)
-        print(config.debug)  # False
+    An inner class named ``Config`` is read the same way, which is what
+    earlier versions documented. Prefer ``Env``: Pydantic uses ``Config`` for
+    its own deprecated class-based settings and warns whenever it sees one.
+
+    Set ``SILLO_ENV_FILE`` to point every config at a different file, or to
+    the empty string to turn automatic loading off — useful in tests, where
+    the environment should be the only source.
     """
 
     model_config = ConfigDict(
@@ -45,42 +91,86 @@ class Config(BaseModel):
     )
 
     def __init__(
-        self, _env_file: str | None = None, _case_sensitive: bool = False, **data
+        self,
+        _env_file: str | None = _UNSET,
+        _case_sensitive: bool = _UNSET,
+        _env_prefix: str = _UNSET,
+        **data: Any,
     ):
-        """Initialize config, loading from .env if configured.
+        """Initialize config, reading the environment and the ``.env`` file.
 
         Parameters:
-            _env_file: Path to .env file to load (overrides Config.env_file)
-            _case_sensitive: Whether environment variable names are case-sensitive (overrides Config.case_sensitive)
-            **data: Configuration values to set
+            _env_file: The file to load, overriding the inner ``Config``.
+                ``None`` loads no file; left out, the project's ``.env`` is
+                found and loaded once.
+            _case_sensitive: Whether field names map to environment variables
+                verbatim rather than uppercased.
+            _env_prefix: Prepended to every environment variable name.
+            **data: Values that take precedence over the environment.
         """
-        # Check if subclass has env_file config
-        config_dict = (
-            getattr(self.__class__.Config, "__dict__", {})
-            if hasattr(self.__class__, "Config")
-            else {}
+        options = self._options()
+
+        env_file = (
+            _env_file if _env_file is not _UNSET else options.get("env_file", _UNSET)
         )
-        env_file = _env_file or config_dict.get("env_file")
-        case_sensitive = _case_sensitive or config_dict.get("case_sensitive", False)
+        case_sensitive = (
+            _case_sensitive
+            if _case_sensitive is not _UNSET
+            else options.get("case_sensitive", False)
+        )
+        prefix = (
+            _env_prefix if _env_prefix is not _UNSET else options.get("env_prefix", "")
+        )
 
-        # Load .env file if specified
-        if env_file:
-            from dotenv import load_dotenv
+        if env_file is _UNSET:
+            # Nothing was asked for: find the project's .env, once per process.
+            autoload()
+        elif env_file is not None:
+            load_env(env_file)
 
-            load_dotenv(env_file)
+        env_data: dict[str, Any] = {}
+        for name, field in self.__class__.model_fields.items():
+            alias = field.alias if isinstance(field.alias, str) else None
+            for candidate in (alias, name):
+                if candidate is None:
+                    continue
+                key = prefix + candidate
+                if not case_sensitive:
+                    key = key.upper()
+                if key in os.environ:
+                    # Keyed by alias when there is one, so the value lands
+                    # whether or not the model populates by name.
+                    env_data[alias or name] = os.environ[key]
+                    break
 
-        # Load from environment variables
-        import os
-
-        env_data = {}
-        for field_name in self.__class__.model_fields:
-            env_key = field_name if case_sensitive else field_name.upper()
-            if env_key in os.environ:
-                env_data[field_name] = os.environ[env_key]
-
-        # Merge with provided data (provided data takes precedence)
+        # Explicit arguments beat anything the environment had to say.
         env_data.update(data)
         super().__init__(**env_data)
+
+    @classmethod
+    def _options(cls) -> dict[str, Any]:
+        """Read the subclass's inner options class.
+
+        ``Env`` is the one to write. ``Config`` still works — it is what
+        earlier versions documented — but Pydantic claims that name for its
+        own deprecated class-based settings, so it warns on every model that
+        uses it.
+
+        Returns:
+            The options declared, or an empty mapping.
+        """
+        for name in ("Env", "Config"):
+            inner = getattr(cls, name, None)
+            if inner is None or inner is cls or not isinstance(inner, type):
+                continue
+            options = {
+                key: value
+                for key, value in vars(inner).items()
+                if not key.startswith("__")
+            }
+            if options:
+                return options
+        return {}
 
     def __repr__(self) -> str:
         """Pretty repr that masks secrets."""
@@ -92,24 +182,20 @@ class Config(BaseModel):
                 fields_repr[field_name] = field_value
         return f"<{self.__class__.__name__} {fields_repr}>"
 
+    def __str__(self) -> str:
+        """The masked repr.
+
+        Pydantic's ``__str__`` prints every field's value, and ``print(config)``
+        calls ``__str__``, not ``__repr__`` — so masking only the repr leaks
+        the secrets at the one moment somebody is most likely to look.
+        """
+        return self.__repr__()
+
     @staticmethod
     def _is_secret_field(field_name: str) -> bool:
         """Check if field name suggests it contains a secret."""
-        secret_keywords = (
-            "secret",
-            "key",
-            "password",
-            "token",
-            "apikey",
-            "api_key",
-            "auth",
-            "credential",
-            "private",
-        )
-        return any(keyword in field_name.lower() for keyword in secret_keywords)
+        return any(keyword in field_name.lower() for keyword in SECRET_KEYWORDS)
 
 
 # Re-export Pydantic Field for convenience
 Field = PydanticField
-
-__all__ = ["Config", "Field"]

--- a/sillo/env/__init__.py
+++ b/sillo/env/__init__.py
@@ -1,0 +1,46 @@
+"""``.env`` support, without a dependency.
+
+Sillo reads ``.env`` files itself — ``python-dotenv`` is not required, not
+installed, and not imported anywhere in the framework.
+
+Most projects never call anything here. :class:`sillo.SilloApp` and
+:class:`sillo.config.Config` load the project's ``.env`` on their own, so
+``os.environ`` is already populated by the time application code runs::
+
+    from sillo.config import Config
+
+    class Settings(Config):
+        database_url: str
+        debug: bool = False
+
+    settings = Settings()   # .env has already been read
+
+The functions are here for the times that is not enough — a second file, a
+different precedence, or one value read straight out of the environment::
+
+    from sillo.env import env, find_env, load_env, parse_env
+
+    load_env(".env.local", override=True)   # layer a local file on top
+    port = env("PORT", 8000, cast=int)      # one typed read
+    values = parse_env(text)                # parse without touching os.environ
+"""
+
+from sillo.env._loader import (
+    DEFAULT_ENV_FILE,
+    ENV_FILE_VARIABLE,
+    autoload,
+    env,
+    find_env,
+    load_env,
+    parse_env,
+)
+
+__all__ = [
+    "DEFAULT_ENV_FILE",
+    "ENV_FILE_VARIABLE",
+    "autoload",
+    "env",
+    "find_env",
+    "load_env",
+    "parse_env",
+]

--- a/sillo/env/_loader.py
+++ b/sillo/env/_loader.py
@@ -1,0 +1,492 @@
+"""Read ``.env`` files.
+
+Sillo parses ``.env`` itself. Nothing in this module imports ``python-dotenv``,
+and no application needs it installed: :class:`sillo.config.Config` and
+:class:`sillo.SilloApp` both call :func:`autoload` on the way up, so the
+variables a project keeps in ``.env`` are in ``os.environ`` before the first
+line of application code reads one.
+
+The grammar
+-----------
+
+::
+
+    KEY=value                     # bare, everything to end of line
+    KEY="value"                   # escapes and ${REFERENCES} resolved
+    KEY='value'                   # taken literally, nothing resolved
+    KEY=\"\"\"multi              # newlines belong to the value
+    line\"\"\"
+    export KEY=value              # the prefix is dropped
+    # a comment                   # whole-line comments are skipped
+    KEY=value # trailing comment  # needs the space; `a#b` is the value `a#b`
+
+References resolve against names defined earlier in the same file first, then
+against the surrounding environment. ``${NAME:-fallback}`` supplies a value
+when ``NAME`` is unset or empty, ``${NAME-fallback}`` only when it is unset,
+and an unresolved reference becomes the empty string. Write ``\\$`` (or use a
+single-quoted value) for a literal dollar sign — the case that otherwise
+mangles passwords.
+
+Precedence
+----------
+
+A variable already present in the real environment wins over the file, so a
+deploy that exports ``DATABASE_URL`` beats a ``.env`` left in the image. Pass
+``override=True`` to reverse that.
+"""
+
+from __future__ import annotations
+
+import os
+from collections.abc import Callable, Mapping, MutableMapping
+from pathlib import Path
+from typing import Any
+
+__all__ = [
+    "autoload",
+    "env",
+    "find_env",
+    "load_env",
+    "parse_env",
+]
+
+#: The file looked for when no path is given.
+DEFAULT_ENV_FILE = ".env"
+
+#: Points :func:`autoload` at a different file. Set it to the empty string to
+#: turn automatic loading off entirely.
+ENV_FILE_VARIABLE = "SILLO_ENV_FILE"
+
+#: The upward search for a ``.env`` stops at the directory holding one of
+#: these, so a stray ``~/.env`` never leaks into a project.
+ROOT_MARKERS = ("pyproject.toml", "uv.lock", "setup.py", "setup.cfg", ".git")
+
+_TRUE = frozenset({"1", "true", "t", "yes", "y", "on"})
+_FALSE = frozenset({"0", "false", "f", "no", "n", "off", ""})
+
+# `\<newline>` maps to "" so a double-quoted value can be wrapped over lines.
+_ESCAPES = {
+    "n": "\n",
+    "r": "\r",
+    "t": "\t",
+    "b": "\b",
+    "f": "\f",
+    "v": "\v",
+    "0": "\0",
+    "a": "\a",
+    "\\": "\\",
+    '"': '"',
+    "'": "'",
+    "$": "$",
+    "`": "`",
+    "\n": "",
+}
+
+_MISSING: Any = object()
+
+
+# ---------------------------------------------------------------------------
+# Parsing
+# ---------------------------------------------------------------------------
+
+
+def _is_key(key: str) -> bool:
+    """Whether *key* is a usable environment variable name."""
+    return key.isascii() and key.isidentifier()
+
+
+def _end_of_line(text: str, index: int) -> int:
+    """Index just past the newline that ends the line containing *index*."""
+    newline = text.find("\n", index)
+    return len(text) if newline == -1 else newline + 1
+
+
+def _lookup(
+    name: str,
+    values: Mapping[str, str],
+    environ: Mapping[str, str],
+) -> str | None:
+    """Resolve *name*, the file's own values first."""
+    if name in values:
+        return values[name]
+    return environ.get(name)
+
+
+def _reference(
+    text: str,
+    index: int,
+    values: Mapping[str, str],
+    environ: Mapping[str, str],
+) -> tuple[str, int]:
+    """Resolve the reference starting at ``text[index] == '$'``.
+
+    Returns the replacement text and the index just past the reference. A
+    ``$`` that begins nothing recognisable is returned as itself.
+    """
+    if index + 1 >= len(text):
+        return "$", index + 1
+
+    if text[index + 1] == "{":
+        close = text.find("}", index + 2)
+        if close == -1:
+            return "$", index + 1
+        body = text[index + 2 : close]
+        after = close + 1
+
+        if ":-" in body:
+            name, _, fallback = body.partition(":-")
+            resolved = _lookup(name, values, environ)
+            return (fallback if not resolved else resolved), after
+        if "-" in body:
+            name, _, fallback = body.partition("-")
+            resolved = _lookup(name, values, environ)
+            return (fallback if resolved is None else resolved), after
+
+        return (_lookup(body, values, environ) or ""), after
+
+    end = index + 1
+    while end < len(text) and (text[end].isalnum() or text[end] == "_"):
+        end += 1
+    if end == index + 1:
+        return "$", index + 1
+    return (_lookup(text[index + 1 : end], values, environ) or ""), end
+
+
+def _interpolate(
+    raw: str,
+    values: Mapping[str, str],
+    environ: Mapping[str, str],
+    *,
+    escapes: bool,
+) -> str:
+    """Resolve escapes and references in one pass.
+
+    One pass rather than two because unescaping first would turn ``\\$HOME``
+    into a reference to ``HOME`` instead of the literal text the backslash
+    asked for.
+    """
+    out: list[str] = []
+    i = 0
+    while i < len(raw):
+        char = raw[i]
+        if char == "\\" and i + 1 < len(raw):
+            following = raw[i + 1]
+            if escapes:
+                # An unknown escape keeps both characters: a Windows path in
+                # a quoted value stays the path it looks like.
+                out.append(_ESCAPES.get(following, "\\" + following))
+                i += 2
+                continue
+            if following == "$":
+                out.append("$")
+                i += 2
+                continue
+        if char == "$":
+            replacement, i = _reference(raw, i, values, environ)
+            out.append(replacement)
+            continue
+        out.append(char)
+        i += 1
+    return "".join(out)
+
+
+def _strip_comment(raw: str) -> str:
+    """Drop a trailing ``# comment`` from an unquoted value.
+
+    The ``#`` has to follow whitespace, so ``KEY=pass#word`` keeps its hash
+    the way every shell and ``python-dotenv`` do.
+    """
+    for position, char in enumerate(raw):
+        if char == "#" and (position == 0 or raw[position - 1] in " \t"):
+            return raw[:position]
+    return raw
+
+
+def _read_value(
+    text: str,
+    index: int,
+    values: Mapping[str, str],
+    environ: Mapping[str, str],
+) -> tuple[str, int]:
+    """Read the value starting at *index*, returning it and the next index."""
+    while index < len(text) and text[index] in " \t":
+        index += 1
+
+    for quote in ('"""', "'''"):
+        if text.startswith(quote, index):
+            close = text.find(quote, index + 3)
+            if close == -1:
+                # Unterminated: take the rest of the file rather than lose it.
+                body, after = text[index + 3 :], len(text)
+            else:
+                body, after = text[index + 3 : close], _end_of_line(text, close + 3)
+            if quote == "'''":
+                return body, after
+            return _interpolate(body, values, environ, escapes=True), after
+
+    if index < len(text) and text[index] in "\"'":
+        quote = text[index]
+        cursor = index + 1
+        chunk: list[str] = []
+        while cursor < len(text):
+            char = text[cursor]
+            if char == "\\" and quote == '"' and cursor + 1 < len(text):
+                chunk.append(text[cursor : cursor + 2])
+                cursor += 2
+                continue
+            if char == quote:
+                body = "".join(chunk)
+                after = _end_of_line(text, cursor + 1)
+                if quote == "'":
+                    return body, after
+                return _interpolate(body, values, environ, escapes=True), after
+            chunk.append(char)
+            cursor += 1
+        # Unterminated quote: treat the opener as part of a bare value.
+
+    stop = _end_of_line(text, index)
+    raw = text[index:stop].rstrip("\n").rstrip("\r")
+    raw = _strip_comment(raw).strip()
+    return _interpolate(raw, values, environ, escapes=False), stop
+
+
+def parse_env(text: str, *, environ: Mapping[str, str] | None = None) -> dict[str, str]:
+    """Parse the contents of a ``.env`` file.
+
+    Pure: nothing is written to the process environment. Lines that are not
+    ``KEY=value`` are skipped rather than raising, because a half-typed line
+    in a ``.env`` should not stop an application from booting.
+
+    Args:
+        text: The file's contents.
+        environ: What ``${REFERENCES}`` fall back to once the file's own
+            values are exhausted. Defaults to ``os.environ``. Pass ``{}`` to
+            resolve against the file alone.
+
+    Returns:
+        The variables the file defines, in the order they appear. A key
+        repeated in the file keeps its last value.
+    """
+    surroundings = os.environ if environ is None else environ
+    values: dict[str, str] = {}
+
+    index = 0
+    if text.startswith("﻿"):
+        index = 1
+
+    while index < len(text):
+        char = text[index]
+        if char in " \t\r\n":
+            index += 1
+            continue
+        if char == "#":
+            index = _end_of_line(text, index)
+            continue
+
+        start = index
+        while index < len(text) and text[index] not in "=\r\n":
+            index += 1
+        if index >= len(text) or text[index] != "=":
+            index = _end_of_line(text, index)
+            continue
+
+        key = text[start:index].strip()
+        index += 1
+        if key.startswith(("export ", "export\t")):
+            key = key[6:].lstrip()
+
+        value, index = _read_value(text, index, values, surroundings)
+        if _is_key(key):
+            values[key] = value
+
+    return values
+
+
+# ---------------------------------------------------------------------------
+# Files
+# ---------------------------------------------------------------------------
+
+
+def find_env(
+    name: str = DEFAULT_ENV_FILE,
+    start: str | os.PathLike[str] | None = None,
+) -> Path | None:
+    """Search *start* and its parents for an env file.
+
+    The walk stops at the first directory holding one of :data:`ROOT_MARKERS`,
+    so running a command from ``project/app/handlers`` finds the project's
+    ``.env`` while a file in the user's home directory is never picked up.
+
+    Args:
+        name: The file name to look for.
+        start: Where to begin. Defaults to the working directory.
+
+    Returns:
+        The path found, or ``None``.
+    """
+    try:
+        directory = Path(start or os.getcwd()).resolve()
+    except OSError:
+        return None
+
+    for candidate in (directory, *directory.parents):
+        target = candidate / name
+        if target.is_file():
+            return target
+        if any((candidate / marker).exists() for marker in ROOT_MARKERS):
+            return None
+    return None
+
+
+def load_env(
+    path: str | os.PathLike[str] | None = None,
+    *,
+    override: bool = False,
+    search: bool = True,
+    environ: MutableMapping[str, str] | None = None,
+) -> dict[str, str]:
+    """Load an env file into the process environment.
+
+    A missing or unreadable file is not an error — most projects have no
+    ``.env`` in production, where the variables are exported by the platform.
+
+    Args:
+        path: The file to read. ``None`` looks for ``.env``.
+        override: Whether file values replace variables that are already set.
+            Off by default: the real environment is the more specific source.
+        search: Whether ``None`` should search parent directories
+            (:func:`find_env`) or only look in the working directory.
+        environ: The mapping to write to. Defaults to ``os.environ``.
+
+    Returns:
+        The variables that were applied, which excludes any the environment
+        already had unless *override* was set.
+    """
+    target = os.environ if environ is None else environ
+
+    if path is None:
+        found = find_env() if search else Path(DEFAULT_ENV_FILE)
+        if found is None or not found.is_file():
+            return {}
+        source = found
+    else:
+        source = Path(path)
+
+    try:
+        text = source.read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError):
+        return {}
+
+    applied: dict[str, str] = {}
+    for key, value in parse_env(text, environ=target).items():
+        if override or key not in target:
+            target[key] = value
+            applied[key] = value
+    return applied
+
+
+#: Files :func:`autoload` has already read, so constructing a hundred configs
+#: reads the file once.
+_loaded: set[Path] = set()
+
+
+def autoload() -> Path | None:
+    """Load the project's ``.env`` once.
+
+    Called by :class:`sillo.SilloApp` and :class:`sillo.config.Config`, which
+    is what makes ``.env`` work without an application doing anything. Set
+    ``SILLO_ENV_FILE`` to load a different file, or to the empty string to
+    switch automatic loading off.
+
+    Returns:
+        The file that was loaded or had already been loaded, or ``None``.
+    """
+    configured = os.environ.get(ENV_FILE_VARIABLE)
+    if configured is not None and not configured.strip():
+        return None
+
+    if configured:
+        candidate = Path(configured)
+        if not candidate.is_file():
+            return None
+    else:
+        candidate = find_env() or Path(DEFAULT_ENV_FILE)
+        if not candidate.is_file():
+            return None
+
+    resolved = candidate.resolve()
+    if resolved in _loaded:
+        return resolved
+
+    load_env(resolved)
+    _loaded.add(resolved)
+    return resolved
+
+
+def _reset_autoload() -> None:
+    """Forget which files :func:`autoload` has read. For tests."""
+    _loaded.clear()
+
+
+# ---------------------------------------------------------------------------
+# Reading
+# ---------------------------------------------------------------------------
+
+
+def _to_bool(raw: str) -> bool:
+    """Read a boolean the way a ``.env`` file writes one."""
+    lowered = raw.strip().lower()
+    if lowered in _TRUE:
+        return True
+    if lowered in _FALSE:
+        return False
+    raise ValueError(f"{raw!r} is not a boolean")
+
+
+def env(
+    key: str,
+    default: Any = _MISSING,
+    *,
+    cast: Callable[[str], Any] | None = None,
+) -> Any:
+    """Read one environment variable, with a type.
+
+    For the odd value that does not deserve a :class:`~sillo.config.Config`
+    class::
+
+        from sillo.env import env
+
+        port = env("PORT", 8000, cast=int)
+        debug = env("DEBUG", False, cast=bool)
+        secret = env("JWT_SECRET")          # raises if it is not set
+
+    Args:
+        key: The variable name.
+        default: Returned unchanged when the variable is unset. Omit it to
+            make the variable required.
+        cast: Applied to the string. ``bool`` understands ``true/yes/on/1``
+            and their opposites rather than Python's "any non-empty string".
+
+    Returns:
+        The cast value, or *default*.
+
+    Raises:
+        KeyError: If the variable is unset and no default was given.
+        ValueError: If *cast* rejects the value.
+    """
+    if key not in os.environ:
+        if default is _MISSING:
+            raise KeyError(f"{key} is not set, and has no default")
+        return default
+
+    raw = os.environ[key]
+    if cast is None:
+        return raw
+    if cast is bool:
+        return _to_bool(raw)
+    try:
+        return cast(raw)
+    except (TypeError, ValueError) as error:
+        raise ValueError(
+            f"{key}={raw!r} is not a valid {getattr(cast, '__name__', cast)}: {error}"
+        ) from error

--- a/sillo/hashing/core.py
+++ b/sillo/hashing/core.py
@@ -42,7 +42,7 @@ def _get_context() -> Any:
 
     if _context is None:
         try:
-            from passlib.context import CryptContext  # noqa: PLC0415
+            from passlib.context import CryptContext
         except ImportError as exc:
             raise HashingError(
                 "passlib is required for non-bcrypt hashing schemes. "

--- a/tests/test_config/test_env_loading.py
+++ b/tests/test_config/test_env_loading.py
@@ -1,0 +1,377 @@
+"""Config reads the project's .env without being asked to.
+
+The behaviour these cover is the point of the whole module: a project writes
+a ``.env``, declares a config class, and installs nothing extra.
+"""
+
+import os
+
+import pytest
+
+from sillo.config import Config, Field
+from sillo.env import _loader
+from sillo.env._loader import ENV_FILE_VARIABLE
+
+
+@pytest.fixture(autouse=True)
+def clean_env():
+    """Undo environment writes and autoload's memory between tests."""
+    original = dict(os.environ)
+    _loader._reset_autoload()
+
+    yield
+
+    os.environ.clear()
+    os.environ.update(original)
+    _loader._reset_autoload()
+
+
+@pytest.fixture
+def project(tmp_path, monkeypatch):
+    """A project directory that is the working directory."""
+    (tmp_path / "pyproject.toml").write_text("[project]\n")
+    monkeypatch.chdir(tmp_path)
+    names = (
+        "DATABASE_URL",
+        "DB_URL",
+        "DB_HOST",
+        "DATABASE_POOL_SIZE",
+        "MAIL_HOST",
+        "URL",
+        "JWT_SECRET",
+        "DEBUG",
+        "PORT",
+        ENV_FILE_VARIABLE,
+    )
+    for key in names:
+        monkeypatch.delenv(key, raising=False)
+        monkeypatch.delenv(key.lower(), raising=False)
+    return tmp_path
+
+
+class Settings(Config):
+    """Declared at module level, the way an application declares one."""
+
+    database_url: str
+    debug: bool = False
+    port: int = 8000
+
+
+class TestAutomaticLoading:
+    """No inner class, no arguments, no dotenv."""
+
+    def test_the_projects_env_file_is_loaded(self, project):
+        (project / ".env").write_text(
+            "DATABASE_URL=postgres://localhost/app\nDEBUG=true\nPORT=9000\n"
+        )
+
+        config = Settings()
+
+        assert config.database_url == "postgres://localhost/app"
+        assert config.debug is True
+        assert config.port == 9000
+
+    def test_types_come_from_the_annotations(self, project):
+        (project / ".env").write_text("DATABASE_URL=x\nPORT=9000\n")
+
+        config = Settings()
+
+        assert isinstance(config.port, int)
+        assert isinstance(config.debug, bool)
+
+    def test_found_from_a_subdirectory(self, project, monkeypatch):
+        (project / ".env").write_text("DATABASE_URL=postgres://localhost/app\n")
+        nested = project / "app" / "handlers"
+        nested.mkdir(parents=True)
+        monkeypatch.chdir(nested)
+
+        assert Settings().database_url == "postgres://localhost/app"
+
+    def test_defaults_apply_when_the_file_is_silent(self, project):
+        (project / ".env").write_text("DATABASE_URL=postgres://localhost/app\n")
+
+        config = Settings()
+
+        assert config.debug is False
+        assert config.port == 8000
+
+    def test_a_missing_file_is_not_an_error(self, project):
+        os.environ["DATABASE_URL"] = "postgres://localhost/app"
+
+        assert Settings().database_url == "postgres://localhost/app"
+
+    def test_a_missing_required_value_fails_at_construction(self, project):
+        with pytest.raises(Exception) as error:
+            Settings()
+
+        assert "database_url" in str(error.value)
+
+    def test_the_real_environment_wins_over_the_file(self, project):
+        (project / ".env").write_text("DATABASE_URL=from-the-file\n")
+        os.environ["DATABASE_URL"] = "from-the-platform"
+
+        assert Settings().database_url == "from-the-platform"
+
+    def test_arguments_win_over_both(self, project):
+        (project / ".env").write_text("DATABASE_URL=from-the-file\n")
+        os.environ["DATABASE_URL"] = "from-the-platform"
+
+        assert Settings(database_url="explicit").database_url == "explicit"
+
+    def test_references_inside_the_file_resolve(self, project):
+        (project / ".env").write_text(
+            "DB_HOST=db.internal\nDATABASE_URL=postgres://${DB_HOST}/app\n"
+        )
+
+        assert Settings().database_url == "postgres://db.internal/app"
+
+    def test_the_file_is_read_once_for_many_configs(self, project):
+        path = project / ".env"
+        path.write_text("DATABASE_URL=first\n")
+        Settings()
+
+        path.write_text("DATABASE_URL=second\n")
+        del os.environ["DATABASE_URL"]
+
+        with pytest.raises(Exception):
+            Settings()
+
+
+class TestOptOut:
+    """Turning the automatic load off."""
+
+    def test_env_file_none_loads_no_file(self, project):
+        (project / ".env").write_text("DATABASE_URL=from-the-file\n")
+        os.environ["DATABASE_URL"] = "from-the-environment"
+
+        class Isolated(Config):
+            database_url: str
+
+            class Env:
+                env_file = None
+
+        assert Isolated().database_url == "from-the-environment"
+        assert "DEBUG" not in os.environ
+
+    def test_empty_env_file_variable_turns_it_off(self, project):
+        (project / ".env").write_text("DATABASE_URL=from-the-file\n")
+        os.environ[ENV_FILE_VARIABLE] = ""
+        os.environ["DATABASE_URL"] = "from-the-environment"
+
+        assert Settings().database_url == "from-the-environment"
+
+    def test_env_file_variable_selects_another_file(self, project):
+        (project / ".env").write_text("DATABASE_URL=development\n")
+        (project / ".env.production").write_text("DATABASE_URL=production\n")
+        os.environ[ENV_FILE_VARIABLE] = str(project / ".env.production")
+
+        assert Settings().database_url == "production"
+
+
+class TestExplicitFile:
+    """Naming a file, in the class or at the call."""
+
+    def test_inner_env_class(self, project):
+        (project / ".env.production").write_text("DATABASE_URL=production\n")
+
+        class Production(Config):
+            database_url: str
+
+            class Env:
+                env_file = ".env.production"
+
+        assert Production().database_url == "production"
+
+    def test_inner_config_class_still_works(self, project):
+        (project / ".env.production").write_text("DATABASE_URL=production\n")
+
+        class Production(Config):
+            database_url: str
+
+            class Config:
+                env_file = ".env.production"
+
+        assert Production().database_url == "production"
+
+    def test_argument_overrides_the_class(self, project):
+        (project / ".env.production").write_text("DATABASE_URL=production\n")
+        (project / ".env.staging").write_text("DATABASE_URL=staging\n")
+
+        class Production(Config):
+            database_url: str
+
+            class Env:
+                env_file = ".env.production"
+
+        config = Production(_env_file=str(project / ".env.staging"))
+        assert config.database_url == "staging"
+
+
+class TestPrefix:
+    """``env_prefix``, so one file can hold several subsystems."""
+
+    def test_fields_read_prefixed_variables(self, project):
+        (project / ".env").write_text(
+            "DATABASE_URL=postgres://localhost/app\nDATABASE_POOL_SIZE=20\n"
+        )
+
+        class DatabaseConfig(Config):
+            url: str
+            pool_size: int = 10
+
+            class Env:
+                env_prefix = "DATABASE_"
+
+        config = DatabaseConfig()
+
+        assert config.url == "postgres://localhost/app"
+        assert config.pool_size == 20
+
+    def test_the_unprefixed_name_is_not_read(self, project):
+        os.environ["URL"] = "unprefixed"
+
+        class DatabaseConfig(Config):
+            url: str = "default"
+
+            class Env:
+                env_prefix = "DATABASE_"
+                env_file = None
+
+        assert DatabaseConfig().url == "default"
+
+    def test_two_configs_share_one_file(self, project):
+        (project / ".env").write_text("DATABASE_URL=postgres://db\nMAIL_HOST=smtp.test\n")
+
+        class DatabaseConfig(Config):
+            url: str
+
+            class Env:
+                env_prefix = "DATABASE_"
+
+        class MailConfig(Config):
+            host: str
+
+            class Env:
+                env_prefix = "MAIL_"
+
+        assert DatabaseConfig().url == "postgres://db"
+        assert MailConfig().host == "smtp.test"
+
+    def test_prefix_argument_overrides_the_class(self, project):
+        os.environ["OTHER_URL"] = "other"
+
+        class DatabaseConfig(Config):
+            url: str
+
+            class Env:
+                env_prefix = "DATABASE_"
+                env_file = None
+
+        assert DatabaseConfig(_env_prefix="OTHER_").url == "other"
+
+
+class TestCaseSensitivity:
+    """Field names are uppercased unless told otherwise."""
+
+    def test_uppercased_by_default(self, project):
+        os.environ["DATABASE_URL"] = "postgres://localhost/app"
+
+        assert Settings().database_url == "postgres://localhost/app"
+
+    def test_case_sensitive_reads_the_field_name_verbatim(self, project):
+        os.environ["database_url"] = "lowercase"
+        os.environ["DATABASE_URL"] = "uppercase"
+
+        class Exact(Config):
+            database_url: str
+
+            class Env:
+                case_sensitive = True
+                env_file = None
+
+        assert Exact().database_url == "lowercase"
+
+    def test_case_sensitive_false_argument_overrides_the_class(self, project):
+        os.environ["DATABASE_URL"] = "uppercase"
+
+        class Exact(Config):
+            database_url: str
+
+            class Env:
+                case_sensitive = True
+                env_file = None
+
+        assert Exact(_case_sensitive=False).database_url == "uppercase"
+
+
+class TestAliases:
+    """A field whose environment variable has a different name."""
+
+    def test_the_alias_names_the_variable(self, project):
+        os.environ["DB_URL"] = "postgres://localhost/app"
+
+        class Aliased(Config):
+            database_url: str = Field(alias="db_url")
+
+            class Env:
+                env_file = None
+
+        assert Aliased().database_url == "postgres://localhost/app"
+
+    def test_the_field_name_still_works(self, project):
+        os.environ["DATABASE_URL"] = "postgres://localhost/app"
+
+        class Aliased(Config):
+            database_url: str = Field(alias="db_url")
+
+            model_config = {"populate_by_name": True}
+
+            class Env:
+                env_file = None
+
+        assert Aliased().database_url == "postgres://localhost/app"
+
+    def test_the_alias_wins_when_both_are_set(self, project):
+        os.environ["DB_URL"] = "by-alias"
+        os.environ["DATABASE_URL"] = "by-name"
+
+        class Aliased(Config):
+            database_url: str = Field(alias="db_url")
+
+            class Env:
+                env_file = None
+
+        assert Aliased().database_url == "by-alias"
+
+
+class TestMasking:
+    """Secrets stay out of output that people actually look at."""
+
+    class Secrets(Config):
+        jwt_secret: str
+        api_key: str
+        name: str
+
+        class Env:
+            env_file = None
+
+    def test_repr_masks_secrets(self, project):
+        config = self.Secrets(jwt_secret="s3cret", api_key="sk-123", name="public")
+
+        assert "s3cret" not in repr(config)
+        assert "sk-123" not in repr(config)
+        assert "public" in repr(config)
+
+    def test_str_masks_them_too(self, project):
+        # print() calls __str__, which Pydantic writes out in full. That is
+        # the moment a secret would otherwise reach a terminal or a log.
+        config = self.Secrets(jwt_secret="s3cret", api_key="sk-123", name="public")
+
+        assert "s3cret" not in str(config)
+        assert "sk-123" not in str(config)
+        assert "public" in str(config)
+
+    def test_the_values_are_still_readable(self, project):
+        config = self.Secrets(jwt_secret="s3cret", api_key="sk-123", name="public")
+
+        assert config.jwt_secret == "s3cret"

--- a/tests/test_env/conftest.py
+++ b/tests/test_env/conftest.py
@@ -1,0 +1,33 @@
+"""Fixtures for the .env loader tests."""
+
+import os
+
+import pytest
+
+from sillo.env import _loader
+
+
+@pytest.fixture(autouse=True)
+def clean_env():
+    """Restore os.environ, and forget what autoload has already read.
+
+    ``load_env`` writes to ``os.environ`` directly rather than through
+    monkeypatch, and ``autoload`` remembers files across calls by design, so
+    both need undoing between tests.
+    """
+    original = dict(os.environ)
+    _loader._reset_autoload()
+
+    yield
+
+    os.environ.clear()
+    os.environ.update(original)
+    _loader._reset_autoload()
+
+
+@pytest.fixture
+def project(tmp_path, monkeypatch):
+    """A directory that looks like a project root, and is the cwd."""
+    (tmp_path / "pyproject.toml").write_text("[project]\nname = 'demo'\n")
+    monkeypatch.chdir(tmp_path)
+    return tmp_path

--- a/tests/test_env/test_load.py
+++ b/tests/test_env/test_load.py
@@ -1,0 +1,312 @@
+"""Finding .env files, loading them, and reading single variables."""
+
+import os
+import re
+from pathlib import Path
+
+import pytest
+
+from sillo.env import ENV_FILE_VARIABLE, autoload, env, find_env, load_env
+
+
+class TestFindEnv:
+    """Where the file is looked for."""
+
+    def test_finds_it_in_the_working_directory(self, project):
+        (project / ".env").write_text("KEY=value\n")
+        assert find_env() == project / ".env"
+
+    def test_finds_it_in_a_parent(self, project, monkeypatch):
+        (project / ".env").write_text("KEY=value\n")
+        nested = project / "app" / "handlers"
+        nested.mkdir(parents=True)
+        monkeypatch.chdir(nested)
+
+        assert find_env() == project / ".env"
+
+    def test_stops_at_the_project_root(self, tmp_path, monkeypatch):
+        # A .env above the project must not be picked up: that is somebody's
+        # home directory, and its variables are not this project's.
+        (tmp_path / ".env").write_text("OUTSIDE=1\n")
+        inner = tmp_path / "project"
+        inner.mkdir()
+        (inner / "pyproject.toml").write_text("[project]\n")
+        monkeypatch.chdir(inner)
+
+        assert find_env() is None
+
+    def test_returns_none_when_there_is_none(self, project):
+        assert find_env() is None
+
+    def test_walks_to_the_top_when_no_marker_is_found(self, tmp_path, monkeypatch):
+        nested = tmp_path / "a" / "b"
+        nested.mkdir(parents=True)
+        monkeypatch.chdir(nested)
+
+        assert find_env(".env.nothing-is-named-this") is None
+
+    def test_a_directory_named_env_is_not_a_file(self, project):
+        (project / ".env").mkdir()
+        assert find_env() is None
+
+    def test_looks_for_the_name_it_is_given(self, project):
+        (project / ".env.production").write_text("KEY=value\n")
+        assert find_env(".env.production") == project / ".env.production"
+
+    def test_starts_where_it_is_told(self, project, tmp_path):
+        elsewhere = tmp_path / "elsewhere"
+        elsewhere.mkdir()
+        (elsewhere / "pyproject.toml").write_text("[project]\n")
+        (elsewhere / ".env").write_text("KEY=value\n")
+
+        assert find_env(start=elsewhere) == elsewhere / ".env"
+
+
+class TestLoadEnv:
+    """What reaches the environment."""
+
+    def test_loads_a_file_by_path(self, tmp_path):
+        path = tmp_path / ".env"
+        path.write_text("SILLO_TEST_A=1\nSILLO_TEST_B=two\n")
+
+        applied = load_env(path)
+
+        assert applied == {"SILLO_TEST_A": "1", "SILLO_TEST_B": "two"}
+        assert os.environ["SILLO_TEST_A"] == "1"
+        assert os.environ["SILLO_TEST_B"] == "two"
+
+    def test_accepts_a_string_path(self, tmp_path):
+        path = tmp_path / ".env"
+        path.write_text("SILLO_TEST_A=1\n")
+
+        load_env(str(path))
+
+        assert os.environ["SILLO_TEST_A"] == "1"
+
+    def test_the_real_environment_wins(self, tmp_path):
+        os.environ["SILLO_TEST_A"] = "from-the-platform"
+        path = tmp_path / ".env"
+        path.write_text("SILLO_TEST_A=from-the-file\n")
+
+        applied = load_env(path)
+
+        assert os.environ["SILLO_TEST_A"] == "from-the-platform"
+        assert applied == {}
+
+    def test_override_reverses_that(self, tmp_path):
+        os.environ["SILLO_TEST_A"] = "from-the-platform"
+        path = tmp_path / ".env"
+        path.write_text("SILLO_TEST_A=from-the-file\n")
+
+        applied = load_env(path, override=True)
+
+        assert os.environ["SILLO_TEST_A"] == "from-the-file"
+        assert applied == {"SILLO_TEST_A": "from-the-file"}
+
+    def test_a_missing_file_is_not_an_error(self, tmp_path):
+        assert load_env(tmp_path / "nothing-here") == {}
+
+    def test_a_directory_is_not_an_error(self, tmp_path):
+        assert load_env(tmp_path) == {}
+
+    def test_undecodable_bytes_are_not_an_error(self, tmp_path):
+        path = tmp_path / ".env"
+        path.write_bytes(b"KEY=\xff\xfe\n")
+
+        assert load_env(path) == {}
+
+    def test_writes_to_the_mapping_it_is_given(self, tmp_path):
+        path = tmp_path / ".env"
+        path.write_text("SILLO_TEST_A=1\n")
+        target = {}
+
+        load_env(path, environ=target)
+
+        assert target == {"SILLO_TEST_A": "1"}
+        assert "SILLO_TEST_A" not in os.environ
+
+    def test_finds_the_file_when_given_no_path(self, project):
+        (project / ".env").write_text("SILLO_TEST_A=found\n")
+
+        assert load_env() == {"SILLO_TEST_A": "found"}
+
+    def test_no_search_looks_only_in_the_working_directory(self, project, monkeypatch):
+        (project / ".env").write_text("SILLO_TEST_A=found\n")
+        nested = project / "app"
+        nested.mkdir()
+        monkeypatch.chdir(nested)
+
+        assert load_env(search=False) == {}
+        assert load_env(search=True) == {"SILLO_TEST_A": "found"}
+
+    def test_layering_a_local_file_on_top(self, project):
+        (project / ".env").write_text("SILLO_TEST_A=shared\nSILLO_TEST_B=shared\n")
+        (project / ".env.local").write_text("SILLO_TEST_A=mine\n")
+
+        load_env()
+        load_env(project / ".env.local", override=True)
+
+        assert os.environ["SILLO_TEST_A"] == "mine"
+        assert os.environ["SILLO_TEST_B"] == "shared"
+
+    def test_references_resolve_against_the_live_environment(self, tmp_path):
+        os.environ["SILLO_TEST_HOST"] = "db.internal"
+        path = tmp_path / ".env"
+        path.write_text("SILLO_TEST_URL=postgres://$SILLO_TEST_HOST/app\n")
+
+        load_env(path)
+
+        assert os.environ["SILLO_TEST_URL"] == "postgres://db.internal/app"
+
+
+class TestAutoload:
+    """The automatic load the framework performs."""
+
+    def test_loads_the_projects_env(self, project):
+        (project / ".env").write_text("SILLO_TEST_A=1\n")
+
+        assert autoload() == (project / ".env").resolve()
+        assert os.environ["SILLO_TEST_A"] == "1"
+
+    def test_reads_the_file_once(self, project):
+        path = project / ".env"
+        path.write_text("SILLO_TEST_A=first\n")
+        autoload()
+
+        # A second call must not re-read: something may have changed the
+        # variable deliberately since startup.
+        path.write_text("SILLO_TEST_A=second\n")
+        del os.environ["SILLO_TEST_A"]
+        autoload()
+
+        assert "SILLO_TEST_A" not in os.environ
+
+    def test_does_nothing_without_a_file(self, project):
+        assert autoload() is None
+
+    def test_env_file_variable_points_it_elsewhere(self, project):
+        (project / ".env").write_text("SILLO_TEST_A=default\n")
+        (project / ".env.production").write_text("SILLO_TEST_A=production\n")
+        os.environ[ENV_FILE_VARIABLE] = str(project / ".env.production")
+
+        autoload()
+
+        assert os.environ["SILLO_TEST_A"] == "production"
+
+    def test_empty_env_file_variable_turns_it_off(self, project):
+        (project / ".env").write_text("SILLO_TEST_A=1\n")
+        os.environ[ENV_FILE_VARIABLE] = ""
+
+        assert autoload() is None
+        assert "SILLO_TEST_A" not in os.environ
+
+    def test_a_configured_file_that_is_missing_is_not_an_error(self, project):
+        os.environ[ENV_FILE_VARIABLE] = str(project / "nothing-here")
+
+        assert autoload() is None
+
+
+class TestEnvAccessor:
+    """``env()`` for the one-off read."""
+
+    def test_reads_a_string(self):
+        os.environ["SILLO_TEST_A"] = "value"
+        assert env("SILLO_TEST_A") == "value"
+
+    def test_returns_the_default_when_unset(self):
+        assert env("SILLO_TEST_MISSING", "fallback") == "fallback"
+
+    def test_a_variable_with_no_default_is_required(self):
+        with pytest.raises(KeyError, match="SILLO_TEST_MISSING"):
+            env("SILLO_TEST_MISSING")
+
+    def test_casts_to_int(self):
+        os.environ["SILLO_TEST_PORT"] = "8000"
+        assert env("SILLO_TEST_PORT", cast=int) == 8000
+
+    def test_casts_to_float(self):
+        os.environ["SILLO_TEST_TIMEOUT"] = "1.5"
+        assert env("SILLO_TEST_TIMEOUT", cast=float) == 1.5
+
+    def test_casts_with_any_callable(self):
+        os.environ["SILLO_TEST_HOSTS"] = "a.test,b.test"
+        assert env("SILLO_TEST_HOSTS", cast=lambda raw: raw.split(",")) == [
+            "a.test",
+            "b.test",
+        ]
+
+    @pytest.mark.parametrize("raw", ["1", "true", "TRUE", "yes", "on", "y"])
+    def test_true_words(self, raw):
+        os.environ["SILLO_TEST_DEBUG"] = raw
+        assert env("SILLO_TEST_DEBUG", cast=bool) is True
+
+    @pytest.mark.parametrize("raw", ["0", "false", "FALSE", "no", "off", "n", ""])
+    def test_false_words(self, raw):
+        # Not Python's truthiness: "false" is a non-empty string, and every
+        # config that gets this wrong ships debug mode to production.
+        os.environ["SILLO_TEST_DEBUG"] = raw
+        assert env("SILLO_TEST_DEBUG", cast=bool) is False
+
+    def test_a_value_that_is_not_a_boolean(self):
+        os.environ["SILLO_TEST_DEBUG"] = "maybe"
+        with pytest.raises(ValueError):
+            env("SILLO_TEST_DEBUG", cast=bool)
+
+    def test_a_value_that_is_not_an_int(self):
+        os.environ["SILLO_TEST_PORT"] = "eighty"
+        with pytest.raises(ValueError, match="SILLO_TEST_PORT"):
+            env("SILLO_TEST_PORT", cast=int)
+
+    def test_the_default_is_returned_uncast(self):
+        assert env("SILLO_TEST_MISSING", None, cast=int) is None
+
+
+class TestNoDotenv:
+    """The dependency this module exists to avoid."""
+
+    def test_the_framework_does_not_import_python_dotenv(self):
+        source = Path(__file__).resolve().parents[2] / "sillo"
+        importing = re.compile(r"^\s*(?:from dotenv\b|import dotenv\b)", re.MULTILINE)
+        offenders = [
+            str(path.relative_to(source))
+            for path in source.rglob("*.py")
+            if importing.search(path.read_text(encoding="utf-8", errors="ignore"))
+        ]
+        assert offenders == []
+
+    def test_python_dotenv_is_not_a_declared_dependency(self):
+        pyproject = Path(__file__).resolve().parents[2] / "pyproject.toml"
+        text = pyproject.read_text(encoding="utf-8")
+        assert "python-dotenv" not in text
+
+
+class TestFrameworkLoadsItself:
+    """The framework reads .env on its own, which is the whole point."""
+
+    def test_building_an_application_loads_the_projects_env(self, project):
+        from sillo import SilloApp
+
+        (project / ".env").write_text("SILLO_TEST_APP_KEY=loaded\n")
+
+        SilloApp(title="demo")
+
+        assert os.environ["SILLO_TEST_APP_KEY"] == "loaded"
+
+    def test_an_application_does_not_override_the_platform(self, project):
+        from sillo import SilloApp
+
+        os.environ["SILLO_TEST_APP_KEY"] = "from-the-platform"
+        (project / ".env").write_text("SILLO_TEST_APP_KEY=from-the-file\n")
+
+        SilloApp(title="demo")
+
+        assert os.environ["SILLO_TEST_APP_KEY"] == "from-the-platform"
+
+    def test_the_console_loads_it_before_finding_the_application(self, project):
+        from sillo.__main__ import build_console
+
+        (project / ".env").write_text("SILLO_TEST_CONSOLE_KEY=loaded\n")
+
+        build_console()
+
+        assert os.environ["SILLO_TEST_CONSOLE_KEY"] == "loaded"

--- a/tests/test_env/test_parse.py
+++ b/tests/test_env/test_parse.py
@@ -1,0 +1,234 @@
+"""Parsing .env text.
+
+``parse_env`` is pure, so every case here is a string in and a dict out —
+nothing touches the process environment.
+"""
+
+import pytest
+
+from sillo.env import parse_env
+
+
+def parse(text, **kwargs):
+    """Parse against an empty environment unless a test says otherwise."""
+    kwargs.setdefault("environ", {})
+    return parse_env(text, **kwargs)
+
+
+class TestBasics:
+    """The shape of a line."""
+
+    def test_simple_assignment(self):
+        assert parse("KEY=value") == {"KEY": "value"}
+
+    def test_several_lines(self):
+        assert parse("A=1\nB=2\nC=3") == {"A": "1", "B": "2", "C": "3"}
+
+    def test_surrounding_whitespace_is_dropped(self):
+        assert parse("  KEY  =  value  ") == {"KEY": "value"}
+
+    def test_export_prefix_is_dropped(self):
+        assert parse("export KEY=value") == {"KEY": "value"}
+
+    def test_empty_value(self):
+        assert parse("KEY=") == {"KEY": ""}
+
+    def test_value_containing_equals(self):
+        assert parse("DSN=user=admin;pass=x") == {"DSN": "user=admin;pass=x"}
+
+    def test_last_definition_wins(self):
+        assert parse("KEY=first\nKEY=second") == {"KEY": "second"}
+
+    def test_blank_lines_and_whitespace(self):
+        assert parse("\n\n  \nKEY=value\n\n") == {"KEY": "value"}
+
+    def test_no_trailing_newline(self):
+        assert parse("A=1\nB=2") == {"A": "1", "B": "2"}
+
+    def test_crlf_line_endings(self):
+        assert parse("A=1\r\nB=2\r\n") == {"A": "1", "B": "2"}
+
+    def test_byte_order_mark_is_ignored(self):
+        assert parse("\ufeffKEY=value") == {"KEY": "value"}
+
+    def test_empty_text(self):
+        assert parse("") == {}
+
+
+class TestComments:
+    """What counts as a comment."""
+
+    def test_whole_line_comment(self):
+        assert parse("# nothing here\nKEY=value") == {"KEY": "value"}
+
+    def test_indented_comment(self):
+        assert parse("   # nothing here\nKEY=value") == {"KEY": "value"}
+
+    def test_trailing_comment(self):
+        assert parse("KEY=value # explain") == {"KEY": "value"}
+
+    def test_hash_without_leading_space_stays(self):
+        # The case that silently corrupts passwords when a parser is greedy.
+        assert parse("PASSWORD=pa#ssword") == {"PASSWORD": "pa#ssword"}
+
+    def test_hash_inside_quotes_stays(self):
+        assert parse('URL="https://example.com/#anchor"') == {
+            "URL": "https://example.com/#anchor"
+        }
+
+    def test_comment_after_quoted_value(self):
+        assert parse('KEY="value" # explain') == {"KEY": "value"}
+
+
+class TestQuoting:
+    """Quotes, and what they turn off."""
+
+    def test_double_quotes_are_stripped(self):
+        assert parse('KEY="value"') == {"KEY": "value"}
+
+    def test_single_quotes_are_stripped(self):
+        assert parse("KEY='value'") == {"KEY": "value"}
+
+    def test_quotes_preserve_spaces(self):
+        assert parse('KEY="  spaced  "') == {"KEY": "  spaced  "}
+
+    def test_escape_sequences_in_double_quotes(self):
+        assert parse(r'KEY="line\nbreak\ttab"') == {"KEY": "line\nbreak\ttab"}
+
+    def test_escaped_quote_in_double_quotes(self):
+        assert parse(r'KEY="say \"hi\""') == {"KEY": 'say "hi"'}
+
+    def test_single_quotes_take_the_text_literally(self):
+        assert parse(r"KEY='line\nbreak'") == {"KEY": r"line\nbreak"}
+
+    def test_unknown_escape_keeps_both_characters(self):
+        # A Windows path in a quoted value stays the path it looks like.
+        assert parse(r'KEY="C:\Users\demo"') == {"KEY": r"C:\Users\demo"}
+
+    def test_double_quoted_value_spans_lines(self):
+        assert parse('KEY="one\ntwo"\nNEXT=3') == {"KEY": "one\ntwo", "NEXT": "3"}
+
+    def test_triple_double_quotes(self):
+        text = 'KEY="""line one\nline two"""\nNEXT=3'
+        assert parse(text) == {"KEY": "line one\nline two", "NEXT": "3"}
+
+    def test_triple_single_quotes_are_literal(self):
+        text = "KEY='''raw $VAR\\n'''\nNEXT=3"
+        assert parse(text) == {"KEY": "raw $VAR\\n", "NEXT": "3"}
+
+    def test_certificate_over_many_lines(self):
+        text = 'CERT="""-----BEGIN KEY-----\nabc\ndef\n-----END KEY-----"""'
+        assert parse(text)["CERT"].endswith("-----END KEY-----")
+
+    def test_unterminated_quote_does_not_raise(self):
+        assert parse('KEY="unclosed') == {"KEY": '"unclosed'}
+
+    def test_unterminated_triple_quote_takes_the_rest(self):
+        assert parse('KEY="""unclosed\nmore') == {"KEY": "unclosed\nmore"}
+
+
+class TestReferences:
+    """``$VAR`` and ``${VAR}``."""
+
+    def test_braced_reference_to_earlier_key(self):
+        assert parse("HOST=example.com\nURL=https://${HOST}/api")["URL"] == (
+            "https://example.com/api"
+        )
+
+    def test_bare_reference_to_earlier_key(self):
+        assert parse("HOST=example.com\nURL=https://$HOST/api")["URL"] == (
+            "https://example.com/api"
+        )
+
+    def test_reference_resolves_inside_double_quotes(self):
+        assert parse('A=1\nB="value-$A"') == {"A": "1", "B": "value-1"}
+
+    def test_reference_is_literal_inside_single_quotes(self):
+        assert parse("A=1\nB='value-$A'") == {"A": "1", "B": "value-$A"}
+
+    def test_unresolved_reference_is_empty(self):
+        assert parse("URL=host-${NOPE}-end")["URL"] == "host--end"
+
+    def test_falls_back_to_the_surrounding_environment(self):
+        values = parse_env("URL=https://$HOST", environ={"HOST": "outside.test"})
+        assert values["URL"] == "https://outside.test"
+
+    def test_the_file_wins_over_the_surrounding_environment(self):
+        values = parse_env("HOST=inside.test\nURL=https://$HOST", environ={"HOST": "outside.test"})
+        assert values["URL"] == "https://inside.test"
+
+    def test_default_when_unset(self):
+        assert parse("PORT=${PORT:-8000}") == {"PORT": "8000"}
+
+    def test_default_is_not_used_when_set(self):
+        assert parse("A=5\nPORT=${A:-8000}")["PORT"] == "5"
+
+    def test_colon_dash_default_covers_the_empty_string(self):
+        assert parse("A=\nPORT=${A:-8000}")["PORT"] == "8000"
+
+    def test_dash_default_keeps_the_empty_string(self):
+        assert parse("A=\nPORT=${A-8000}")["PORT"] == ""
+
+    def test_dash_default_applies_when_unset(self):
+        assert parse("PORT=${NOPE-8000}")["PORT"] == "8000"
+
+    def test_default_may_contain_dashes(self):
+        assert parse("NAME=${NOPE:-a-b-c}")["NAME"] == "a-b-c"
+
+    def test_escaped_dollar_is_literal(self):
+        assert parse(r"PASSWORD=pa\$\$word") == {"PASSWORD": "pa$$word"}
+
+    def test_escaped_dollar_is_literal_inside_quotes(self):
+        assert parse(r'PASSWORD="pa\$word"') == {"PASSWORD": "pa$word"}
+
+    def test_lone_dollar_survives(self):
+        assert parse("KEY=100$") == {"KEY": "100$"}
+
+    def test_dollar_before_punctuation_survives(self):
+        assert parse("KEY=$-x") == {"KEY": "$-x"}
+
+    def test_unclosed_brace_survives(self):
+        assert parse("KEY=${UNCLOSED") == {"KEY": "${UNCLOSED"}
+
+
+class TestMalformed:
+    """A bad line is skipped, never raised."""
+
+    @pytest.mark.parametrize(
+        "line",
+        [
+            "no equals sign here",
+            "9STARTS_WITH_DIGIT=x",
+            "HAS SPACE=x",
+            "HAS-DASH=x",
+            "=novalue",
+            "  ",
+        ],
+    )
+    def test_bad_lines_are_skipped(self, line):
+        assert parse(line) == {}
+
+    def test_a_bad_line_does_not_stop_the_file(self):
+        text = "GOOD=1\nthis line is nonsense\nALSO_GOOD=2"
+        assert parse(text) == {"GOOD": "1", "ALSO_GOOD": "2"}
+
+    def test_non_ascii_key_is_skipped(self):
+        assert parse("CAFÉ=x\nOK=1") == {"OK": "1"}
+
+    def test_unicode_values_are_kept(self):
+        assert parse("GREETING=héllo → 世界") == {"GREETING": "héllo → 世界"}
+
+
+class TestPurity:
+    """``parse_env`` writes nothing."""
+
+    def test_os_environ_is_untouched(self):
+        import os
+
+        assert "PARSE_ONLY_KEY" not in os.environ
+        parse_env("PARSE_ONLY_KEY=value")
+        assert "PARSE_ONLY_KEY" not in os.environ
+
+    def test_defaults_to_os_environ_for_references(self, monkeypatch):
+        monkeypatch.setenv("AMBIENT_HOST", "ambient.test")
+        assert parse_env("URL=https://$AMBIENT_HOST")["URL"] == "https://ambient.test"


### PR DESCRIPTION
## Why

A project should not have to install a dependency, and remember to call it early enough, for `.env` to work. `python-dotenv` was in core's dependency list purely so `Config` could call `load_dotenv()`, and even then the file was only read when a class explicitly named it.

Sillo now parses `.env` itself and loads it on the way up. `python-dotenv` leaves `[project.dependencies]`.

## The loader

`sillo/env/_loader.py` was already in the tree (untracked), but it parsed line by line. Two consequences:

- the multi-line triple-quoted values its own docstring advertised never worked — the file was read `for line in fh`, so a certificate or private key was truncated at the first newline
- values were cut at the first `#`, so `PASSWORD=pa#ssword` silently became `pa`

It is now a scanner over the whole text:

| Form | Behaviour |
|------|-----------|
| `KEY=value` | to end of line, trimmed |
| `KEY="value"` | escapes (`\n`, `\t`, `\"`) and `${REFERENCES}` resolved |
| `KEY='value'` | literal — nothing expanded or unescaped |
| `KEY="""…"""` / `'''…'''` | multi-line, for certificates and keys |
| `export KEY=value` | prefix dropped |
| `KEY=value # note` | comment dropped — **whitespace before `#` required** |
| `KEY=pa#ssword` | the hash is part of the value |

References resolve against names defined earlier in the same file first, then the surrounding environment. `${NAME:-fallback}` covers unset-or-empty, `${NAME-fallback}` only unset, `\$` is a literal dollar. CRLF and BOM handled; a malformed line is skipped rather than raised, because a half-typed `.env` should not stop an application from booting.

## Loading it without being asked

`SilloApp(...)`, every `sillo.config.Config` subclass, and the `sillo` command each call `autoload()`, which reads the project's `.env` **once per process**. The console loads it before the project is imported, so a module that reads `os.environ` at import time sees it too.

The file is found by walking up from the working directory and **stopping at the project root** (`pyproject.toml`, `uv.lock`, `setup.py`, `setup.cfg`, `.git`). `sillo serve` from `myproject/app/handlers` finds `myproject/.env`; a stray `~/.env` is never picked up.

Precedence, most specific first:

1. arguments — `Settings(database_url=…)`
2. the real environment — what the shell, container or platform exported
3. `.env`

An exported variable beating the file is what lets one image run in every environment. `load_env(..., override=True)` reverses it for the cases that want the file to win.

`SILLO_ENV_FILE` names a different file, or turns automatic loading off entirely when set empty — useful in tests, where the environment should be the only source.

## Public API

```python
from sillo.env import env, find_env, load_env, parse_env

load_env(".env.local", override=True)   # layering, since there is no implicit .env.local
port = env("PORT", 8000, cast=int)      # one typed read
values = parse_env(text)                # pure: touches nothing
```

`cast=bool` understands what `.env` files actually contain — `true/yes/on/1` and their opposites — rather than Python's rule where the string `"false"` is true.

## Config changes

- **`env_prefix`** — makes the `DATABASE_URL` / `DATABASE_POOL_SIZE` mapping the documentation has always described actually work. It was documented in `advanced/configuration.md` and never implemented; every prefixed example in those docs was wrong.
- **Aliases name the variable** — `Field(alias="db_url")` now reads `DB_URL`, and the value is keyed by alias so it lands whether or not the model populates by name.
- **Options move to an inner `Env` class.** Pydantic claims `Config` for its own deprecated class-based settings and warns on every model that declares one — and removes it in V3. An inner `Config` is still read, so nothing breaks.

```python
class DatabaseConfig(Config):
    url: str
    pool_size: int = 10

    class Env:
        env_prefix = "DATABASE_"   # env_file = None loads no file at all
```

## Fixed: `print(config)` leaked secrets

Found while running `examples/config/01_basic_config.py`. `__repr__` masked fields whose names look like secrets, but `print()` calls `__str__`, which Pydantic writes out in full — the one moment somebody is most likely to be looking at a terminal or a log. Both mask now.

```
before: jwt_secret='dev-secret-key-not-for-production' …
after:  <AppConfig {… 'jwt_secret': '***' …}>
```

## Tests

162 new tests in `tests/test_env/` and `tests/test_config/test_env_loading.py`: the grammar (quoting, escapes, multi-line, comments, malformed lines, unicode), references and defaults, the upward search and its project-root stop, precedence and `override`, `autoload` caching and its opt-outs, the `env()` casts, and that no module in the framework imports dotenv or declares it as a dependency.

- **4828 passed, 60 skipped, 0 failed**
- 99% coverage on `sillo/env` and 100% on `sillo/config` (the two uncovered lines are an `OSError` guard for an unreadable working directory)
- `ruff check`, `ruff format` and `mypy` clean

## Docs

- new **Environment & .env** guide — grammar, precedence, layering, `SILLO_ENV_FILE`, Docker — added to the sidebar
- **Configuration** guide and the internal **Configuration System** reference updated, including two claims they carried that were simply untrue: `DEBUG=yes` does *not* fail validation, and multi-line values *are* supported
- the nine `class Config:` examples in the internal reference now use `class Env:` with the `env_prefix` that makes their own variable tables correct
- examples and `.env.example` updated and run; CHANGELOG entry added
- `npx astro build` completes clean, 252 pages

## Not in this PR

`starter/app/config.py` and `starter-inertia/app/config.py` still pass `_env_file=".env"`. Dropping the argument would be strictly better — it would work from subdirectories — but both install a released `sillo-framework>=0.1.0b1` from PyPI rather than this tree, so the change would silently stop loading `.env` until a release ships with `autoload`. Worth doing as a follow-up once this is released.
