### PR TITLE
fix(routing): decide method-not-allowed once, and make Allow honest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **The router decides "method not allowed" once.** `Route.match` and
+  `Route.handle` each compared the request's method against the route's set,
+  and spelled the comparison differently — `match` uppercased the method,
+  `handle` did not. A lowercase method matched fully and was then refused
+  405 by the route that had just matched it. The check now lives only in
+  `match`, which compares the token as sent (method tokens are case-sensitive
+  per RFC 9110 section 9.1), and the router builds the 405 itself.
+
+- **A 405's `Allow` header names every method the path supports.** The router
+  kept only the first partial match and asked that one route for the header,
+  so a path split across several routes — `@app.get("/items")` and
+  `@app.post("/items")` build two — reported `Allow: GET, HEAD` and left
+  `POST` unnamed. RFC 9110 requires `Allow` to describe the target resource,
+  so the methods are now collected across every route whose path matched.
+
+
 ### Added
 
 - **Sillo reads `.env` itself.** `sillo.env` is a `.env` parser written for

--- a/docs/docs/src/content/docs/advanced/debugging.md
+++ b/docs/docs/src/content/docs/advanced/debugging.md
@@ -32,6 +32,28 @@ graph TD
     K -->|No| M{Match status}
 ```
 
+### 1.0 Read the `Allow` Header First
+
+**Problem**: A 405 leaves you guessing which methods the path does accept.
+
+**Diagnosis**: The `Allow` header on the 405 names them, and it is collected
+across *every* route whose path matched — so a path split across several
+decorators reports all of its methods, not just the first route's:
+
+```bash
+curl -i -X DELETE localhost:8000/items | grep -i allow
+# Allow: GET, HEAD, POST
+```
+
+`HEAD` appearing next to `GET` is expected: `Route.__init__` adds it.
+
+If the header names the method you sent, the method is not the problem —
+the path is matching a *different* route than you think, and the rest of
+this chain applies. If the header is empty or absent, no route's path
+matched at all and you are looking at a 404 in disguise.
+
+**File**: `core/sillo/core/routing/router.py`, `Router.app`
+
 ### 1.1 Middleware Order
 
 **Problem**: Middleware is registered in the wrong order.

--- a/docs/docs/src/content/docs/advanced/routing.md
+++ b/docs/docs/src/content/docs/advanced/routing.md
@@ -45,7 +45,7 @@ graph TD
 
 - Path compilation is **pure**: no ASGI types leak into `route_builder.py`.
   This makes it independently testable.
-- `MatchStatus` is a tri-state enum (`NONE=0`, `PARTIAL=1`, `FULL=2`) that enables 405 Method Not Allowed without a second pass.
+- `MatchStatus` is a tri-state enum (`NONE=0`, `PARTIAL=1`, `FULL=2`) that enables 405 Method Not Allowed without a second pass. It is also the *only* place the method is examined: `match` decides, and nothing downstream asks again.
 - `Group` is a `BaseRoute`, not a `Router`. This lets it participate in the same linear scan as individual routes.
 - Dependency injection propagates **downward** through `mount_router` / `Group` hierarchies via `_set_inherited_dependencies`.
 
@@ -394,7 +394,7 @@ class BaseRoute(ABC):
 | Method | Responsibility |
 |--------|---------------|
 | `match()` | Return `(MatchStatus, params)` for a given request |
-| `handle()` | Execute the request: called only after a `FULL` match |
+| `handle()` | Execute the request: called only after a `FULL` match, so it does not re-check the method |
 | `url_path_for()` | Reverse URL generation for this route |
 | `__call__()` | Makes the route callable as an ASGI app; delegates to `handle` |
 
@@ -471,8 +471,7 @@ def match(self, scope: Scope) -> tuple[MatchStatus, Any]:
         for key, value in matched_params.items():
             matched_params[key] = self.route_info.convertor[key].convert(value)
 
-        is_method_allowed = method.upper() in self.methods
-        if not is_method_allowed:
+        if method not in self.methods:
             return MatchStatus.PARTIAL, matched_params
 
         return MatchStatus.FULL, matched_params
@@ -488,23 +487,31 @@ def match(self, scope: Scope) -> tuple[MatchStatus, Any]:
 4. Path matches but wrong method → `PARTIAL` (enables 405).
 5. `HEAD` is automatically added when `GET` is in `self.methods` (line 366 to
    367).
+6. The comparison is **case-sensitive**. Method tokens are case-sensitive per
+   RFC 9110 section 9.1, so `get` is not `GET` and produces a `PARTIAL` match.
+   Normalisation happens once, at construction (`{method.upper() for ...}`),
+   never per request.
+
+:::note[This used to be asked twice]
+`match` compared `method.upper()` while `handle` compared the method as sent.
+On a `FULL` match the second check could only ever be a no-op — except that
+the two spellings disagreed, so a lowercase method matched fully and was then
+refused 405 by the route that had just matched it. The check now exists only
+here.
+:::
 
 ### Handle method
 
 ```python
 async def handle(self, scope, receive, send):
-    if self.methods and scope["method"] not in self.methods:
-        response = JSONResponse(
-            {"detail": "Method Not Allowed"},
-            status_code=405,
-            headers={"Allow": ", ".join(sorted(self.methods))},
-        )
-        return await response(scope, receive, send)
-
     await self.app(scope, receive, send)
 ```
 
-The 405 response includes an `Allow` header listing the permitted methods, as required by RFC 7231.
+`handle` runs the route's ASGI chain and nothing else. It is reached only
+after `match` returned `FULL`, which already answered "is this method
+allowed" — so there is nothing left for it to decide. The 405 is built by the
+router (see [the dispatch pair](#the-__call__--app-dispatch-pair)), which is
+the only component that can see every route whose path matched.
 
 ### `get_route_handler`: the DI and auth pipeline
 
@@ -638,6 +645,7 @@ async def app(self, scope, receive, send):
     scope["app"] = self
     path_match = None
     path_match_params = {}
+    allowed: set[str] = set()
 
     for route in self.routes:
         match, matched_params = route.match(scope)
@@ -645,13 +653,20 @@ async def app(self, scope, receive, send):
             scope["route_params"] = RouteParam(matched_params)
             await route.handle(scope, receive, send)
             return
-        elif match == MatchStatus.PARTIAL and path_match is None:
-            path_match = route
-            path_match_params = matched_params
+        elif match == MatchStatus.PARTIAL:
+            allowed |= getattr(route, "methods", None) or set()
+            if path_match is None:
+                path_match = route
+                path_match_params = matched_params
 
     if path_match is not None:
         scope["route_params"] = RouteParam(path_match_params)
-        await path_match.handle(scope, receive, send)
+        response = JSONResponse(
+            {"detail": "Method Not Allowed"},
+            status_code=405,
+            headers={"Allow": ", ".join(sorted(allowed))},
+        )
+        await response(scope, receive, send)
         return
 
     if scope.get("type") == "http":
@@ -665,11 +680,33 @@ async def app(self, scope, receive, send):
 1. Build the middleware stack (outermost middleware first).
 2. Linear scan through `self.routes` in registration order.
 3. First `FULL` match → dispatch immediately (return).
-4. First `PARTIAL` match → record as fallback.
-5. If no `FULL` match found, use the `PARTIAL` fallback (triggers 405).
-6. If no match at all → `NotFoundException` (HTTP) or close frame 4404 (WebSocket).
+4. First `PARTIAL` match → record as the fallback, for its route params.
+5. **Every** `PARTIAL` match → union its methods into `allowed`.
+6. If no `FULL` match found, answer the fallback with a 405 built here.
+7. If no match at all → `NotFoundException` (HTTP) or close frame 4404 (WebSocket).
 
 > **Important**: Route registration order matters. More specific routes should be registered before catch-all routes.
+
+#### Why the 405 is built here
+
+`Allow` describes the **target resource**, not the route that happened to
+match first (RFC 9110 section 15.5.6). One path is routinely several `Route`
+objects — `@app.get("/items")` and `@app.post("/items")` build one each — so
+only the loop, which sees them all, can name the full set:
+
+```
+@app.get("/items") + @app.post("/items")
+
+DELETE /items -> 405 | Allow: GET, HEAD, POST
+```
+
+Delegating to `path_match.handle()` instead would report `Allow: GET, HEAD`,
+and *which* methods went missing would depend on the order the decorators
+were written in. Step 4 still keeps the first partial match, because the
+response carries that route's path params on `scope["route_params"]`.
+
+Route middleware does not run for a 405: the response is sent from the loop,
+before any route's ASGI chain is entered.
 
 ### `add_route`: the route registration gateway
 

--- a/sillo/core/routing/router.py
+++ b/sillo/core/routing/router.py
@@ -3190,7 +3190,8 @@ class Router(BaseRouter):
         match is stored and answered with a 405 Method Not Allowed if no full
         match is found later. The 405 is built here rather than delegated to
         the route, so the question "is this method allowed" is asked once per
-        request, in one place.
+        request, in one place, and its ``Allow`` header can name every method
+        the path supports rather than only the first route's.
 
         For HTTP requests that match no route, a ``NotFoundException`` is
         raised which results in a 404 response. For WebSocket connections
@@ -3218,6 +3219,10 @@ class Router(BaseRouter):
 
         path_match = None
         path_match_params: dict[str, Any] = {}
+        # Every method the path supports, not just the first route to claim
+        # it: `Allow` describes the resource, and one path is routinely split
+        # across several Route objects, one per method.
+        allowed: set[str] = set()
 
         for route in self.routes:
             match, matched_params = route.match(scope)
@@ -3225,16 +3230,18 @@ class Router(BaseRouter):
                 scope["route_params"] = RouteParam(matched_params)
                 await route.handle(scope, receive, send)
                 return
-            elif match == MatchStatus.PARTIAL and path_match is None:
-                path_match = route
-                path_match_params = matched_params
+            elif match == MatchStatus.PARTIAL:
+                allowed |= getattr(route, "methods", None) or set()
+                if path_match is None:
+                    path_match = route
+                    path_match_params = matched_params
 
         if path_match is not None:
             scope["route_params"] = RouteParam(path_match_params)
             response = JSONResponse(
                 {"detail": "Method Not Allowed"},
                 status_code=405,
-                headers={"Allow": ", ".join(sorted(path_match.methods))},
+                headers={"Allow": ", ".join(sorted(allowed))},
             )
             await response(scope, receive, send)
             return

--- a/sillo/core/routing/router.py
+++ b/sillo/core/routing/router.py
@@ -564,8 +564,7 @@ class Route(BaseRoute):
             matched_params = match.groupdict()
             for key, value in matched_params.items():
                 matched_params[key] = self.route_info.convertor[key].convert(value)
-            is_method_allowed = method.upper() in self.methods
-            if not is_method_allowed:
+            if method not in self.methods:
                 return MatchStatus.PARTIAL, matched_params
 
             return MatchStatus.FULL, matched_params
@@ -727,11 +726,11 @@ class Route(BaseRoute):
 
         Dispatches the request through the route's ASGI application chain
         which includes all route-specific middleware and the request handler.
-        If the HTTP method is not in the allowed methods list, a 405 Method
-        Not Allowed JSON response is returned instead of invoking the handler.
 
-        This method is called by the router after a successful path match
-        has been confirmed via the ``match`` method.
+        The method has already been checked: the router only calls this after
+        :meth:`match` returned :attr:`MatchStatus.FULL`, which is the same
+        question. A disallowed method never reaches here — the router answers
+        it with a 405 of its own.
 
         Args:
             scope: ASGI scope containing request information including
@@ -741,14 +740,6 @@ class Route(BaseRoute):
             send: ASGI send callable for transmitting the response data
                 back to the client.
         """
-
-        if self.methods and scope["method"] not in self.methods:
-            response = JSONResponse(
-                {"detail": "Method Not Allowed"},
-                status_code=405,
-                headers={"Allow": ", ".join(sorted(self.methods))},
-            )
-            return await response(scope, receive, send)
 
         await self.app(scope, receive, send)
 
@@ -3196,8 +3187,10 @@ class Router(BaseRouter):
         full match is found (both path and HTTP method match), the request
         is dispatched to that route's handler immediately. If only a partial
         match is found (path matches but method does not), the first partial
-        match is stored and used if no full match is found later, enabling
-        proper 405 Method Not Allowed responses.
+        match is stored and answered with a 405 Method Not Allowed if no full
+        match is found later. The 405 is built here rather than delegated to
+        the route, so the question "is this method allowed" is asked once per
+        request, in one place.
 
         For HTTP requests that match no route, a ``NotFoundException`` is
         raised which results in a 404 response. For WebSocket connections
@@ -3238,7 +3231,12 @@ class Router(BaseRouter):
 
         if path_match is not None:
             scope["route_params"] = RouteParam(path_match_params)
-            await path_match.handle(scope, receive, send)
+            response = JSONResponse(
+                {"detail": "Method Not Allowed"},
+                status_code=405,
+                headers={"Allow": ", ".join(sorted(path_match.methods))},
+            )
+            await response(scope, receive, send)
             return
         if scope.get("type") == "http":
             raise NotFoundException

--- a/tests/test_routing/test_http_methods.py
+++ b/tests/test_routing/test_http_methods.py
@@ -506,6 +506,94 @@ async def test_handle_does_not_re_check_the_method():
     assert status == 200
 
 
+async def test_allow_names_every_method_the_path_supports():
+    """RFC 9110: ``Allow`` describes the resource, not the matched route.
+
+    One path is routinely split across several Route objects — ``@app.get``
+    and ``@app.post`` on the same path build two. The router kept only the
+    first partial match and asked it for the header, so the other methods
+    went unnamed and a client was told the resource supports less than it
+    does.
+    """
+    router = Router()
+
+    async def handler(request: Request, response: Response):
+        return response.text("ok")
+
+    router.add_route(Route("/items", handler, methods=["GET"]))
+    router.add_route(Route("/items", handler, methods=["POST"]))
+    router.add_route(Route("/items", handler, methods=["PATCH"]))
+
+    status, headers = await send_request(router, "DELETE", "/items")
+
+    assert status == 405
+    # HEAD comes along with GET, which the route adds for itself.
+    assert headers["allow"] == "GET, HEAD, PATCH, POST"
+
+
+async def test_allow_is_unchanged_for_a_single_route():
+    """The common case keeps the header it already had."""
+    router = Router()
+
+    async def handler(request: Request, response: Response):
+        return response.text("ok")
+
+    router.add_route(Route("/only-get", handler, methods=["GET"]))
+
+    status, headers = await send_request(router, "POST", "/only-get")
+
+    assert status == 405
+    assert headers["allow"] == "GET, HEAD"
+
+
+async def test_allow_does_not_repeat_a_method():
+    """Two routes offering the same method name it once."""
+    router = Router()
+
+    async def handler(request: Request, response: Response):
+        return response.text("ok")
+
+    router.add_route(Route("/items", handler, methods=["GET"]))
+    router.add_route(Route("/items", handler, methods=["GET", "PUT"]))
+
+    status, headers = await send_request(router, "DELETE", "/items")
+
+    assert status == 405
+    assert headers["allow"] == "GET, HEAD, PUT"
+
+
+async def test_allow_only_counts_routes_whose_path_matched():
+    """A method on a different path is not this resource's to offer."""
+    router = Router()
+
+    async def handler(request: Request, response: Response):
+        return response.text("ok")
+
+    router.add_route(Route("/items", handler, methods=["GET"]))
+    router.add_route(Route("/other", handler, methods=["DELETE"]))
+
+    status, headers = await send_request(router, "POST", "/items")
+
+    assert status == 405
+    assert "DELETE" not in headers["allow"]
+
+
+async def test_allow_spans_routes_with_the_same_path_parameters():
+    """Parameterised paths are collected the same way."""
+    router = Router()
+
+    async def handler(request: Request, response: Response, item_id: str):
+        return response.text(item_id)
+
+    router.add_route(Route("/items/{item_id}", handler, methods=["GET"]))
+    router.add_route(Route("/items/{item_id}", handler, methods=["DELETE"]))
+
+    status, headers = await send_request(router, "POST", "/items/42")
+
+    assert status == 405
+    assert headers["allow"] == "DELETE, GET, HEAD"
+
+
 # ========== Router Method Decorators Tests ==========
 
 

--- a/tests/test_routing/test_http_methods.py
+++ b/tests/test_routing/test_http_methods.py
@@ -9,7 +9,44 @@ import pytest
 from sillo import SilloApp
 from sillo.core.http import Request, Response
 from sillo.core.routing import Route, Router
+from sillo.core.routing._utils import MatchStatus
 from sillo.testclient import TestClient
+
+
+async def send_request(router: Router, method: str, path: str):
+    """Drive *router* with one ASGI request, returning (status, headers).
+
+    A raw scope rather than the test client, because the cases here turn on
+    the exact method token — a client is free to normalise it.
+    """
+    sent = []
+
+    async def receive():
+        return {"type": "http.request", "body": b"", "more_body": False}
+
+    async def send(message):
+        sent.append(message)
+
+    scope = {
+        "type": "http",
+        "method": method,
+        "path": path,
+        "raw_path": path.encode(),
+        "query_string": b"",
+        "headers": [],
+        "scheme": "http",
+        "server": ("testserver", 80),
+        "client": ("testclient", 50000),
+    }
+    await router(scope, receive, send)
+
+    start = next(
+        message for message in sent if message["type"] == "http.response.start"
+    )
+    headers = {
+        key.decode().lower(): value.decode() for key, value in start.get("headers", [])
+    }
+    return start["status"], headers
 
 # ========== GET Method Tests ==========
 
@@ -394,6 +431,79 @@ async def test_405_route_params_come_from_the_partial_match():
     )
     assert status == 405
     assert dict(scope["route_params"]) == {"x": "42"}  # ty: ignore[no-matching-overload]
+
+
+async def test_the_method_is_decided_once():
+    """``match`` decides; ``handle`` does not decide again.
+
+    The check lived in both places, and the two disagreed: ``match`` compared
+    ``method.upper()`` against the route's methods while ``handle`` compared
+    the method as sent. A lowercase method therefore matched fully and was
+    then refused 405 by the route it had just matched.
+    """
+    router = Router()
+
+    async def handler(request: Request, response: Response):
+        return response.text("ok")
+
+    route = Route("/only-get", handler, methods=["GET"])
+    router.add_route(route)
+
+    # The method token is case-sensitive (RFC 9110 section 9.1), so "get" is
+    # not GET. Both halves must reach that same conclusion.
+    assert route.match({"type": "http", "method": "get", "path": "/only-get"})[0] is (
+        MatchStatus.PARTIAL
+    )
+    assert route.match({"type": "http", "method": "GET", "path": "/only-get"})[0] is (
+        MatchStatus.FULL
+    )
+
+    status, _ = await send_request(router, "get", "/only-get")
+    assert status == 405
+
+
+async def test_handle_does_not_re_check_the_method():
+    """A full match reaches the handler without a second lookup.
+
+    ``handle`` is only ever called after ``match`` returned FULL, so a method
+    check there could only ever be a no-op — except when it disagreed.
+    """
+    async def handler(request: Request, response: Response):
+        return response.text("reached")
+
+    route = Route("/x", handler, methods=["GET"])
+
+    sent = []
+
+    async def receive():
+        return {"type": "http.request", "body": b"", "more_body": False}
+
+    async def send(message):
+        sent.append(message)
+
+    # A method the route does not allow, handed straight to handle(). The
+    # router never does this; the point is that handle() no longer owns the
+    # decision, so it runs the handler it was given.
+    scope = {
+        "type": "http",
+        "method": "POST",
+        "path": "/x",
+        "raw_path": b"/x",
+        "query_string": b"",
+        "headers": [],
+        "scheme": "http",
+        "server": ("testserver", 80),
+        "client": ("testclient", 50000),
+        "route_params": {},
+    }
+    await route.handle(scope, receive, send)
+
+    status = next(
+        message["status"]
+        for message in sent
+        if message["type"] == "http.response.start"
+    )
+    assert status == 200
 
 
 # ========== Router Method Decorators Tests ==========


### PR DESCRIPTION
Two bugs in the same few lines of the dispatch path, one commit each.

## 1. The method was checked twice, and the two checks disagreed

`Route.match` compared the request's method against the route's set to choose between a full and a partial match. `Route.handle` then compared it again to decide whether to return a 405 — *after* the router had used the first answer to pick the route it was calling.

The dispatch loop calls `handle()` down both branches, which is how the second check survived:

```python
if match == MatchStatus.FULL:
    await route.handle(...)        # method already proven allowed -> no-op
elif match == MatchStatus.PARTIAL and path_match is None:
    path_match = route
...
if path_match is not None:
    await path_match.handle(...)   # method already proven disallowed -> the 405
```

On the full-match branch the second check could only ever be a no-op. It wasn't, because the two spelled the comparison differently:

```python
match():   method.upper() in self.methods
handle():  scope["method"] not in self.methods
```

`self.methods` is uppercased at construction, so a lowercase method matched fully and was then refused by the route that had just matched it:

```
Route(methods=['GET']), self.methods = {'GET', 'HEAD'}
  method='GET'    match()=FULL     handle() -> 200
  method='get'    match()=FULL     handle() -> 405   <- matched, then refused itself
  method='POST'   match()=PARTIAL  handle() -> 405
```

405 is the right answer for `get` — method tokens are case-sensitive (RFC 9110 §9.1) — but it should come from deciding once, not from two halves contradicting each other. `match` now compares the token as sent; normalisation stays at construction, where it belongs. `handle` no longer checks at all, and the router builds the 405 itself on the only branch that ever produced one.

Route middleware still does not run for a 405, exactly as before.

## 2. `Allow` named the wrong methods

RFC 9110 §15.5.6 requires a 405 to carry an `Allow` header naming the methods the **target resource** supports. The router kept only the first partial match and asked that one route:

```
@app.get("/items") + @app.post("/items")
DELETE /items -> 405 | Allow: GET, HEAD          <- POST unnamed

routes: [<Route /items methods={'GET','HEAD'}>, <Route /items methods={'POST'}>]
```

One path is routinely several `Route` objects, one per method decorator. A client that trusts `Allow` concludes the resource rejects POST. Worse, "first" is registration order, so the header changed depending on the order the decorators were written in.

Methods are now unioned across every route whose *path* matched:

```
DELETE /items -> 405 | Allow: GET, HEAD, POST
```

The response still carries the first partial match's route params, which `test_405_route_params_come_from_the_partial_match` pins.

## Tests

Seven added to `tests/test_routing/test_http_methods.py`, with a `send_request` helper that drives the router from a raw ASGI scope — these cases turn on the exact method token, and a test client is free to normalise it.

- the method is decided once, and case-sensitively (`match` returns PARTIAL for `get`, FULL for `GET`, and the router answers 405)
- `handle` does not re-check: handed a disallowed method directly, it runs the handler, because the decision is no longer its
- `Allow` names every method across routes split by decorator
- `Allow` is unchanged for the single-route case
- a method offered by two routes is named once
- routes on a *different* path contribute nothing
- parameterised paths are collected the same way

**4835 passed, 60 skipped.** `ruff check sillo`, `ruff format --check sillo` and `ty check sillo` all clean.

## Not changed

`Group` and the websocket route were checked — neither adds a third method check, so this was exactly the two sites. The 405 is still a direct `JSONResponse` rather than a raised exception, so application-level exception handlers cannot customise it; that is existing behaviour and a larger question than this PR.
