### PR TITLE
Storage: buckets over local disk and object storage

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -104,6 +104,12 @@ hashing-all = [
 # Caching (Redis, in-memory fallback available)
 cache = ["redis>=5.0.0"]
 
+# Object storage. The local and memory drivers need nothing; only the S3
+# driver has a dependency, and it is httpx rather than boto3 — the request
+# signing is a few dozen lines of HMAC, and boto3 is a very large synchronous
+# dependency to carry for it.
+storage-s3 = ["httpx>=0.23.3"]
+
 # Event Distribution (Redis, in-memory fallback available)
 events = ["redis>=5.0.0"]
 

--- a/sillo/storage/__init__.py
+++ b/sillo/storage/__init__.py
@@ -1,0 +1,82 @@
+"""
+sillo.storage — buckets over local disk and S3-compatible object storage.
+
+    from sillo.storage import setup_storage, StorageConfig, BucketConfig
+    from sillo.storage.policies import Owned, Private
+
+    storage = setup_storage(app, StorageConfig(
+        default="attachments",
+        buckets={
+            "attachments": BucketConfig(driver="local", root="storage/attachments"),
+            "avatars": BucketConfig(driver="local", root="storage/avatars",
+                                    policy=Owned(), accepts=("image/png", "image/jpeg")),
+        },
+    ))
+
+    await storage.bucket("avatars").put(f"{user.id}/face.png", upload, user=user)
+
+Five properties this package is built around, each of which forces something:
+
+* **One driver contract** over disk and object storage — so a project can move
+  between them without changing a line, and so a third-party backend has
+  something to conform to.
+* **Streamed uploads that never buffer a whole file** — so ``write`` takes an
+  async iterator and there is no convenience that takes bytes.
+* **Signed URLs scoped by method, expiry, content type and size** — all four,
+  because each one omitted is a permission accidentally granted.
+* **Content-type sniffing, because the declared type is not evidence** — the
+  sniffer decides what is stored and served; the claim is kept only to be
+  compared against it.
+* **Per-bucket access rules as policies, not a public flag** — because the rule
+  most applications want is "this user, under their own prefix", which two
+  values cannot express.
+"""
+
+from __future__ import annotations
+
+from .base import Action, Driver, FileInfo, Page, StorageEvent, Stored, chunks, collect
+from .bucket import Bucket
+from .config import BucketConfig, StorageConfig
+from .drivers import LocalDriver, MemoryDriver
+from .errors import (
+    FileNotFound,
+    PolicyRefused,
+    SignatureInvalid,
+    StorageError,
+    UnsafeKey,
+)
+from .paths import normalise
+from .policies import Owned, Private, Public, ReadOnly, Signed
+from .signing import SignedGrant, Signer
+from .storage import Storage, setup_storage
+
+__all__ = [
+    "Action",
+    "Bucket",
+    "BucketConfig",
+    "Driver",
+    "FileInfo",
+    "FileNotFound",
+    "LocalDriver",
+    "MemoryDriver",
+    "Owned",
+    "Page",
+    "PolicyRefused",
+    "Private",
+    "Public",
+    "ReadOnly",
+    "SignatureInvalid",
+    "Signed",
+    "SignedGrant",
+    "Signer",
+    "Storage",
+    "StorageConfig",
+    "StorageError",
+    "StorageEvent",
+    "Stored",
+    "UnsafeKey",
+    "chunks",
+    "collect",
+    "normalise",
+    "setup_storage",
+]

--- a/sillo/storage/base.py
+++ b/sillo/storage/base.py
@@ -1,0 +1,481 @@
+"""
+sillo.storage.base — the driver contract, and the shapes it deals in.
+
+One contract over local disk and S3-compatible object storage. Everything else
+in this package is either an implementation of it, a policy evaluated around it,
+or a helper it uses; get these signatures right and the rest follows.
+
+Four of them are deliberate, and each closes a failure this package exists to
+avoid.
+
+``put`` takes an async iterator and never bytes.  There is no ``put_bytes``
+convenience, because the moment one exists every caller reaches for it and
+"streamed uploads that never buffer a whole file" becomes a comment rather than
+a property.  A caller who genuinely wants a whole file in memory can write the
+two lines and own that decision.
+
+``page`` is the only way to list.  S3 pages at a thousand keys and local disk
+does not, so a contract returning a plain list is a contract where every project
+works in development and falls over the first time a bucket grows.  Paging in
+the signature makes that impossible to forget.
+
+``signed_url`` is not optional.  Local disk cannot sign anything by itself, so
+the honest alternatives were to let the method raise "unsupported" — which makes
+"one contract" a lie and puts a branch in every project — or to make local
+signing real.  It is real: an HMAC the framework mounts a route to verify.
+
+``stat`` returns the *sniffed* content type.  The type a client declared is a
+string the client chose, and it is recorded separately so the two can be
+compared, but it is never what gets served.
+"""
+
+from __future__ import annotations
+
+import abc
+import dataclasses
+import enum
+import time
+from collections.abc import AsyncIterator, Awaitable, Callable
+
+__all__ = [
+    "Action",
+    "Driver",
+    "FileInfo",
+    "Listener",
+    "Page",
+    "StorageEvent",
+    "Stored",
+]
+
+
+class Action(str, enum.Enum):
+    """What is being done to an object.
+
+    A ``str`` enum so it serialises without a conversion step, and so a policy
+    can be written against the plain name.
+    """
+
+    READ = "read"
+    WRITE = "write"
+    DELETE = "delete"
+    LIST = "list"
+
+
+@dataclasses.dataclass(frozen=True, slots=True)
+class FileInfo:
+    """What is known about one stored object.
+
+    Attributes:
+        key: The object's key, normalised.
+        size: Bytes stored.
+        content_type: The type the object is *served* as, which is what the
+            sniffer decided rather than what the uploader claimed.
+        modified: Unix timestamp of the last write.
+        etag: The backend's version marker, when it has one.
+        declared_type: What the uploader said it was. Kept so the two can be
+            compared and the mismatch reported; never used to serve.
+    """
+
+    key: str
+    size: int
+    content_type: str = "application/octet-stream"
+    modified: float = 0.0
+    etag: str = ""
+    declared_type: str = ""
+
+    @property
+    def mistyped(self) -> bool:
+        """Whether the uploader's claim disagreed with the content.
+
+        Returns:
+            True when a type was declared and the sniffer found another.
+            Interesting on its own: a ``.png`` that is really HTML is the shape
+            of a stored cross-site scripting attempt, not a mistake.
+        """
+        return bool(self.declared_type) and self.declared_type != self.content_type
+
+
+@dataclasses.dataclass(frozen=True, slots=True)
+class Stored:
+    """The result of writing one object.
+
+    Attributes:
+        key: Where it went.
+        size: How much was written.
+        content_type: What it will be served as.
+        etag: The backend's version marker, when it has one.
+    """
+
+    key: str
+    size: int
+    content_type: str
+    etag: str = ""
+
+
+@dataclasses.dataclass(frozen=True, slots=True)
+class Page:
+    """One page of a listing.
+
+    Attributes:
+        files: The objects on this page.
+        prefixes: Common prefixes — the pseudo-directories a delimiter reveals.
+        cursor: Where the next page starts, or an empty string at the end.
+    """
+
+    files: tuple[FileInfo, ...] = ()
+    prefixes: tuple[str, ...] = ()
+    cursor: str = ""
+
+    @property
+    def more(self) -> bool:
+        """Whether another page follows.
+
+        Returns:
+            True when a cursor was returned.
+        """
+        return bool(self.cursor)
+
+
+@dataclasses.dataclass(frozen=True, slots=True)
+class StorageEvent:
+    """One completed operation, for anything watching.
+
+    Attributes:
+        bucket: Which bucket.
+        key: Which object, or the prefix for a listing.
+        action: What was done.
+        driver: The driver's short name.
+        size: Bytes moved, where the operation moves any.
+        duration_ms: How long it took.
+        outcome: ``ok``, ``missing`` or ``error``.
+        error: The message, when the outcome was an error.
+    """
+
+    bucket: str
+    key: str
+    action: Action
+    driver: str
+    size: int = 0
+    duration_ms: float = 0.0
+    outcome: str = "ok"
+    error: str = ""
+    at: float = dataclasses.field(default_factory=time.time)
+
+
+#: Something that wants to be told about completed operations.
+Listener = Callable[[StorageEvent], Awaitable[None] | None]
+
+
+class Driver(abc.ABC):
+    """A place objects can be put and got.
+
+    Subclasses implement the six abstract methods.  Everything a driver has in
+    common — event dispatch, the listener list, its own name — lives here, so
+    that adding a backend is a matter of I/O and not of remembering to emit
+    things.
+
+    Attributes:
+        name: Short lowercase name, used in events and by the interface.
+    """
+
+    name: str = "driver"
+
+    def __init__(self) -> None:
+        """Build a driver with nothing listening."""
+        self._listeners: list[Listener] = []
+
+    # -- the contract ---------------------------------------------------
+
+    @abc.abstractmethod
+    async def write(
+        self,
+        key: str,
+        stream: AsyncIterator[bytes],
+        *,
+        content_type: str = "",
+        declared_type: str = "",
+    ) -> Stored:
+        """Write an object, consuming *stream* as it goes.
+
+        Args:
+            key: Where to put it, already normalised.
+            stream: The content. Consumed once, never materialised whole.
+            content_type: What to serve it as, already decided by the sniffer.
+            declared_type: What the uploader claimed, recorded for comparison.
+
+        Returns:
+            What was written.
+        """
+
+    @abc.abstractmethod
+    def read(self, key: str) -> AsyncIterator[bytes]:
+        """Stream an object back.
+
+        Not a coroutine: it returns the iterator directly, so ``async for``
+        works without an intermediate ``await``.
+
+        Args:
+            key: The object's key.
+
+        Returns:
+            The content, in chunks.
+
+        Raises:
+            FileNotFound: If there is no such object.
+        """
+
+    @abc.abstractmethod
+    async def stat(self, key: str) -> FileInfo:
+        """Describe one object.
+
+        Args:
+            key: The object's key.
+
+        Returns:
+            What is known about it.
+
+        Raises:
+            FileNotFound: If there is no such object.
+        """
+
+    @abc.abstractmethod
+    async def delete(self, key: str) -> bool:
+        """Remove one object.
+
+        Args:
+            key: The object's key.
+
+        Returns:
+            True when something was removed, False when there was nothing to
+            remove. Deleting an absent object is not an error — the caller's
+            intent is satisfied either way.
+        """
+
+    @abc.abstractmethod
+    async def page(
+        self, prefix: str = "", *, cursor: str = "", limit: int = 100
+    ) -> Page:
+        """List one page of objects under a prefix.
+
+        Args:
+            prefix: Only keys starting with this.
+            cursor: Where to resume, from a previous page.
+            limit: Most objects to return.
+
+        Returns:
+            The page, and where the next one starts.
+        """
+
+    @abc.abstractmethod
+    async def close(self) -> None:
+        """Release whatever the driver is holding."""
+
+    # -- provided -------------------------------------------------------
+
+    async def exists(self, key: str) -> bool:
+        """Whether an object is there.
+
+        Args:
+            key: The object's key.
+
+        Returns:
+            True when it exists.
+        """
+        from .errors import FileNotFound
+
+        try:
+            await self.stat(key)
+        except FileNotFound:
+            return False
+        return True
+
+    async def copy(self, source: str, target: str) -> Stored:
+        """Copy one object to another key.
+
+        The default streams through this process, which is correct everywhere
+        and wasteful against a backend that can copy server-side. Drivers that
+        can should override it; the contract suite runs the same assertions
+        either way.
+
+        Args:
+            source: The key to copy from.
+            target: The key to copy to.
+
+        Returns:
+            What was written.
+        """
+        info = await self.stat(source)
+        return await self.write(
+            target,
+            self.read(source),
+            content_type=info.content_type,
+            declared_type=info.declared_type,
+        )
+
+    async def move(self, source: str, target: str) -> Stored:
+        """Move one object to another key.
+
+        Args:
+            source: The key to move from.
+            target: The key to move to.
+
+        Returns:
+            What was written.
+        """
+        stored = await self.copy(source, target)
+        await self.delete(source)
+        return stored
+
+    def signed_url(
+        self,
+        key: str,
+        *,
+        method: str = "GET",
+        expires_in: int = 300,
+        content_type: str = "",
+        max_bytes: int = 0,
+    ) -> str:
+        """A URL that grants one narrow permission for a while.
+
+        Args:
+            key: The object's key.
+            method: The single HTTP method the URL permits.
+            expires_in: Seconds until it stops working.
+            content_type: The single content type a write may carry.
+            max_bytes: The largest body a write may carry.
+
+        Returns:
+            The URL.
+
+        Raises:
+            NotImplementedError: If the driver was built without the means to
+                sign. Every shipped driver can; a third-party one that cannot
+                should say so here rather than returning something that does
+                not work.
+        """
+        raise NotImplementedError(
+            f"{type(self).__name__} cannot sign URLs. Configure it with a "
+            "signer, or use a driver that can."
+        )
+
+    async def capabilities(self) -> dict[str, object]:
+        """What this driver, against this endpoint, can actually do.
+
+        Answered by asking rather than by assuming, because "S3-compatible"
+        is a spectrum and a hardcoded table ages into a lie. ``vise doctor``
+        prints this; a driver reads it to choose an upload strategy.
+
+        Returns:
+            Capability names to values.
+        """
+        return {
+            "driver": self.name,
+            "signed_urls": type(self).signed_url is not Driver.signed_url,
+            "server_side_copy": type(self).copy is not Driver.copy,
+        }
+
+    # -- watching -------------------------------------------------------
+
+    def listen(self, listener: Listener) -> Listener:
+        """Be told about every completed operation.
+
+        This exists in version one on purpose.  Every other sillo subsystem
+        that something wanted to watch — queries, cache, outgoing calls, queues,
+        schedules, events — offered no hook, so the tooling wraps private
+        methods on six different classes, and two of those seams turned out to
+        be the wrong ones in ways nothing reported.  A storage operation is I/O
+        measured in milliseconds; one attribute check per call is free here in a
+        way it is not on the request path.
+
+        Args:
+            listener: Called with each :class:`StorageEvent`.
+
+        Returns:
+            The listener, so this can be used as a decorator.
+        """
+        self._listeners.append(listener)
+        return listener
+
+    def unlisten(self, listener: Listener) -> None:
+        """Stop telling *listener* about operations.
+
+        Args:
+            listener: The listener to drop.
+        """
+        if listener in self._listeners:
+            self._listeners.remove(listener)
+
+    async def emit(self, event: StorageEvent) -> None:
+        """Tell every listener about one operation.
+
+        A listener that raises is dropped from consideration for that event and
+        nothing else: an observer must not be able to fail a write.
+
+        Args:
+            event: What happened.
+        """
+        if not self._listeners:
+            return
+
+        for listener in tuple(self._listeners):
+            try:
+                result = listener(event)
+                if result is not None:
+                    await result
+            except Exception:
+                continue
+
+    def __repr__(self) -> str:
+        """A short description for debugging.
+
+        Returns:
+            The driver's name.
+        """
+        return f"{type(self).__name__}(name={self.name!r})"
+
+
+async def chunks(data: bytes, size: int = 64 * 1024) -> AsyncIterator[bytes]:
+    """Turn bytes into a stream.
+
+    The one place the package builds a stream out of a whole buffer, so that
+    tests and small writes have something to pass to :meth:`Driver.write`
+    without every caller inventing it.
+
+    Args:
+        data: The content.
+        size: Chunk size.
+
+    Yields:
+        The content, in chunks.
+    """
+    for start in range(0, len(data) or 1, size):
+        piece = data[start : start + size]
+        if piece or not data:
+            yield piece
+
+
+async def collect(stream: AsyncIterator[bytes], limit: int = 0) -> bytes:
+    """Read a stream into memory.
+
+    Deliberately explicit, and deliberately takes a limit.  Calling this is a
+    decision to buffer, and the signature makes the caller state how much they
+    are willing to buffer.
+
+    Args:
+        stream: The content.
+        limit: Most bytes to read. Zero means no limit.
+
+    Returns:
+        The content.
+
+    Raises:
+        ValueError: If *limit* is exceeded.
+    """
+    buffer = bytearray()
+
+    async for chunk in stream:
+        buffer.extend(chunk)
+        if limit and len(buffer) > limit:
+            raise ValueError(f"stream exceeded {limit} bytes")
+
+    return bytes(buffer)

--- a/sillo/storage/bucket.py
+++ b/sillo/storage/bucket.py
@@ -1,0 +1,415 @@
+"""
+sillo.storage.bucket — the object a project actually holds.
+
+A :class:`Bucket` is a driver with the four things a driver deliberately does
+not know about wrapped around it: the policy, the sniffer, the size limit, and
+the event.
+
+Keeping those out of the drivers is what makes the contract suite meaningful.
+A driver's job is to move bytes; if it also decided what a file was and who
+could have it, every backend would get its own chance to decide differently.
+"""
+
+from __future__ import annotations
+
+import time
+from collections.abc import AsyncIterator
+from typing import Any
+
+from .base import Action, Driver, FileInfo, Page, StorageEvent, Stored
+from .errors import PolicyRefused, StorageError
+from .paths import normalise
+from .policies import BucketPolicy, Private
+from .sniff import PROBE_BYTES, sniff
+
+__all__ = ["Bucket"]
+
+
+class Bucket:
+    """One named place to put things, with rules.
+
+    Attributes:
+        name: What the project calls it.
+        driver: Where the bytes go.
+        policy: Who may do what.
+        max_bytes: Largest object accepted. Zero for no limit.
+        accepts: Content types accepted after sniffing. Empty for anything.
+    """
+
+    __slots__ = ("accepts", "driver", "max_bytes", "name", "policy")
+
+    def __init__(
+        self,
+        name: str,
+        driver: Driver,
+        *,
+        policy: BucketPolicy | None = None,
+        max_bytes: int = 0,
+        accepts: tuple[str, ...] = (),
+    ) -> None:
+        """Build a bucket.
+
+        Args:
+            name: What to call it.
+            driver: Where the bytes go.
+            policy: Who may do what. Private when unset.
+            max_bytes: Largest object accepted.
+            accepts: Content types accepted, after sniffing.
+        """
+        self.name = name
+        self.driver = driver
+        self.policy = policy or Private()
+        self.max_bytes = max_bytes
+        self.accepts = accepts
+
+    # -- reading and writing --------------------------------------------
+
+    async def put(
+        self,
+        key: str,
+        stream: AsyncIterator[bytes],
+        *,
+        content_type: str = "",
+        user: Any = None,
+        signed: bool = False,
+    ) -> Stored:
+        """Store an object.
+
+        The stream is consumed once.  The first :data:`~sillo.storage.sniff.PROBE_BYTES`
+        are held back to identify the content and then put in front of the rest,
+        so identification costs one small buffer rather than the whole file.
+
+        Args:
+            key: Where to put it.
+            stream: The content.
+            content_type: What the uploader claimed. Recorded, never trusted.
+            user: Who is asking.
+            signed: Whether a valid signature already authorised this.
+
+        Returns:
+            What was written.
+
+        Raises:
+            PolicyRefused: If the policy declines.
+            StorageError: If the object is too large, or is a type this bucket
+                does not accept.
+        """
+        key = normalise(key)
+        self._permit(Action.WRITE, key, user, signed)
+
+        started = time.perf_counter()
+
+        # Read enough to identify the content, but never more than the bucket
+        # will accept. Without the second half, a bucket limited to a kilobyte
+        # still reads four before refusing — which is harmless for a file and
+        # wrong in principle, since the limit is what the caller asked to be
+        # enforced.
+        probe = (
+            PROBE_BYTES if not self.max_bytes else min(PROBE_BYTES, self.max_bytes + 1)
+        )
+        head, rest = await _peek(stream, probe)
+        resolved = sniff(head, declared=content_type, key=key)
+
+        if self.accepts and resolved not in self.accepts:
+            await self._record(key, Action.WRITE, started, outcome="error")
+            raise StorageError(
+                f"{self.name} does not accept {resolved}; it accepts "
+                f"{', '.join(self.accepts)}"
+            )
+
+        try:
+            stored = await self.driver.write(
+                key,
+                _capped(head, rest, self.max_bytes),
+                content_type=resolved,
+                declared_type=content_type,
+            )
+        except Exception as error:
+            await self._record(key, Action.WRITE, started, outcome="error", error=error)
+            raise
+
+        await self._record(key, Action.WRITE, started, size=stored.size)
+        return stored
+
+    async def get(
+        self, key: str, *, user: Any = None, signed: bool = False
+    ) -> AsyncIterator[bytes]:
+        """Stream an object back.
+
+        Args:
+            key: The object's key.
+            user: Who is asking.
+            signed: Whether a valid signature already authorised this.
+
+        Yields:
+            The content, in chunks.
+
+        Raises:
+            PolicyRefused: If the policy declines.
+            FileNotFound: If there is no such object.
+        """
+        key = normalise(key)
+        self._permit(Action.READ, key, user, signed)
+
+        started = time.perf_counter()
+        sent = 0
+
+        async for chunk in self.driver.read(key):
+            sent += len(chunk)
+            yield chunk
+
+        await self._record(key, Action.READ, started, size=sent)
+
+    async def stat(
+        self, key: str, *, user: Any = None, signed: bool = False
+    ) -> FileInfo:
+        """Describe one object.
+
+        Args:
+            key: The object's key.
+            user: Who is asking.
+            signed: Whether a valid signature already authorised this.
+
+        Returns:
+            What is known about it.
+        """
+        key = normalise(key)
+        self._permit(Action.READ, key, user, signed)
+        return await self.driver.stat(key)
+
+    async def exists(self, key: str, *, user: Any = None) -> bool:
+        """Whether an object is there.
+
+        Args:
+            key: The object's key.
+            user: Who is asking.
+
+        Returns:
+            True when it exists.
+        """
+        key = normalise(key)
+        self._permit(Action.READ, key, user, False)
+        return await self.driver.exists(key)
+
+    async def delete(self, key: str, *, user: Any = None, signed: bool = False) -> bool:
+        """Remove one object.
+
+        Args:
+            key: The object's key.
+            user: Who is asking.
+            signed: Whether a valid signature already authorised this.
+
+        Returns:
+            Whether anything was removed.
+        """
+        key = normalise(key)
+        self._permit(Action.DELETE, key, user, signed)
+
+        started = time.perf_counter()
+        removed = await self.driver.delete(key)
+
+        await self._record(
+            key, Action.DELETE, started, outcome="ok" if removed else "missing"
+        )
+        return removed
+
+    async def page(
+        self,
+        prefix: str = "",
+        *,
+        cursor: str = "",
+        limit: int = 100,
+        user: Any = None,
+    ) -> Page:
+        """List one page of objects.
+
+        Args:
+            prefix: Only keys starting with this.
+            cursor: Where to resume.
+            limit: Most objects to return.
+            user: Who is asking.
+
+        Returns:
+            The page.
+        """
+        self._permit(Action.LIST, prefix, user, False)
+
+        started = time.perf_counter()
+        page = await self.driver.page(prefix, cursor=cursor, limit=limit)
+
+        await self._record(prefix, Action.LIST, started, size=len(page.files))
+        return page
+
+    def signed_url(
+        self,
+        key: str,
+        *,
+        method: str = "GET",
+        expires_in: int = 300,
+        content_type: str = "",
+        max_bytes: int = 0,
+    ) -> str:
+        """A URL granting one narrow permission for a while.
+
+        Args:
+            key: The object's key.
+            method: The single permitted method.
+            expires_in: Seconds until it stops working.
+            content_type: The single permitted content type.
+            max_bytes: The largest permitted body. Falls back to the bucket's
+                own limit, so a signed upload slot is never wider than the
+                bucket itself.
+
+        Returns:
+            The URL.
+
+        Raises:
+            PolicyRefused: If the policy will not honour a signature for this.
+        """
+        key = normalise(key)
+        action = Action.READ if method.upper() == "GET" else Action.WRITE
+
+        if not self.policy.signable(action):
+            raise PolicyRefused(action.value, key)
+
+        return self.driver.signed_url(
+            key,
+            method=method,
+            expires_in=expires_in,
+            content_type=content_type,
+            max_bytes=max_bytes or self.max_bytes,
+        )
+
+    # -- internals ------------------------------------------------------
+
+    def _permit(self, action: Action, key: str, user: Any, signed: bool) -> None:
+        """Check the policy, or raise.
+
+        Args:
+            action: What is being attempted.
+            key: On what.
+            user: Who is asking.
+            signed: Whether a valid signature already authorised this.
+
+        Raises:
+            PolicyRefused: If neither the signature nor the user suffices.
+        """
+        if signed and self.policy.signable(action):
+            return
+
+        if not self.policy.allows(action, key, user):
+            raise PolicyRefused(action.value, key)
+
+    async def _record(
+        self,
+        key: str,
+        action: Action,
+        started: float,
+        *,
+        size: int = 0,
+        outcome: str = "ok",
+        error: Exception | None = None,
+    ) -> None:
+        """Tell anything watching what happened.
+
+        Args:
+            key: What was operated on.
+            action: What was done.
+            started: ``perf_counter`` reading from before it.
+            size: Bytes moved.
+            outcome: How it went.
+            error: What went wrong, when something did.
+        """
+        await self.driver.emit(
+            StorageEvent(
+                bucket=self.name,
+                key=key,
+                action=action,
+                driver=self.driver.name,
+                size=size,
+                duration_ms=(time.perf_counter() - started) * 1000,
+                outcome=outcome,
+                error=f"{type(error).__name__}: {error}" if error else "",
+            )
+        )
+
+    def __repr__(self) -> str:
+        """A short description for debugging.
+
+        Returns:
+            The name, driver and policy.
+        """
+        return (
+            f"Bucket({self.name!r}, driver={self.driver.name}, policy={self.policy!r})"
+        )
+
+
+async def _peek(
+    stream: AsyncIterator[bytes], want: int
+) -> tuple[bytes, AsyncIterator[bytes]]:
+    """Read enough of a stream to identify it, without losing it.
+
+    Args:
+        stream: The content.
+        want: How much to read.
+
+    Returns:
+        The leading bytes, and the remainder of the stream.
+    """
+    head = bytearray()
+
+    async for chunk in stream:
+        head.extend(chunk)
+        if len(head) >= want:
+            break
+
+    return bytes(head), stream
+
+
+async def _capped(
+    head: bytes, rest: AsyncIterator[bytes], limit: int
+) -> AsyncIterator[bytes]:
+    """Put the peeked bytes back in front, and stop at the limit.
+
+    The limit is enforced *while streaming*, not by checking a declared
+    ``Content-Length`` — which is a number the uploader chose. A body that
+    claims one megabyte and sends a hundred is refused at the megabyte, having
+    buffered none of it.
+
+    Args:
+        head: What was read to identify the content.
+        rest: The remainder of the stream.
+        limit: Most bytes to accept. Zero for no limit.
+
+    Yields:
+        The whole content.
+
+    Raises:
+        StorageError: If the limit is exceeded.
+    """
+    sent = 0
+
+    for piece in (head,):
+        if piece:
+            sent += len(piece)
+            _check(sent, limit)
+            yield piece
+
+    async for chunk in rest:
+        sent += len(chunk)
+        _check(sent, limit)
+        yield chunk
+
+
+def _check(sent: int, limit: int) -> None:
+    """Refuse a stream that has grown past its limit.
+
+    Args:
+        sent: How much has passed.
+        limit: The ceiling, or zero.
+
+    Raises:
+        StorageError: If the ceiling is passed.
+    """
+    if limit and sent > limit:
+        raise StorageError(f"object exceeds the bucket's limit of {limit} bytes")

--- a/sillo/storage/config.py
+++ b/sillo/storage/config.py
@@ -1,0 +1,94 @@
+"""
+sillo.storage.config — what a project declares.
+
+One dataclass, not a pile of keyword arguments.  ``setup_record`` takes a
+``DatabaseConfig`` and can grow an option without breaking a signature;
+``setup_work`` takes keywords and cannot. This follows the first.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+from typing import Any
+
+__all__ = ["BucketConfig", "StorageConfig"]
+
+
+@dataclasses.dataclass(frozen=True, slots=True)
+class BucketConfig:
+    """One bucket.
+
+    Attributes:
+        driver: ``memory``, ``local`` or ``s3``.
+        policy: Who may do what. Defaults to ``Private()`` — a bucket nobody
+            configured should not be readable because nobody configured it.
+        root: The directory, for the local driver.
+        bucket: The remote bucket name, for S3.
+        endpoint: The S3 endpoint, for anything that is not AWS.
+        region: The S3 region.
+        access_key: The S3 access key. Read from the environment in practice.
+        secret_key: The S3 secret key.
+        max_bytes: Largest object this bucket accepts. Zero for no limit.
+        accepts: Content types this bucket accepts, after sniffing. Empty for
+            anything. Stated as what the *sniffer* decided, so declaring
+            ``image/png`` and uploading HTML is refused here rather than
+            stored.
+    """
+
+    driver: str = "local"
+    policy: Any = None
+    root: str = ""
+    bucket: str = ""
+    endpoint: str = ""
+    region: str = "us-east-1"
+    access_key: str = ""
+    secret_key: str = ""
+    max_bytes: int = 0
+    accepts: tuple[str, ...] = ()
+
+
+@dataclasses.dataclass(frozen=True, slots=True)
+class StorageConfig:
+    """Every bucket, and what they share.
+
+    Attributes:
+        buckets: Bucket names to their configuration.
+        default: Which bucket ``storage.bucket()`` returns unasked.
+        secret: What signs URLs. Falls back to the application's own secret.
+        route: Where the serving route is mounted. Every signed URL points
+            under this.
+        serve: Mount the serving route at all. Off means signed URLs can still
+            be minted for S3, which serves them itself, and local ones have
+            nowhere to point.
+    """
+
+    buckets: dict[str, BucketConfig] = dataclasses.field(default_factory=dict)
+    default: str = ""
+    secret: str = ""
+    route: str = "/storage"
+    serve: bool = True
+
+    def bucket(self, name: str = "") -> BucketConfig:
+        """One bucket's configuration.
+
+        Args:
+            name: The bucket's name, or empty for the default.
+
+        Returns:
+            Its configuration.
+
+        Raises:
+            KeyError: If no such bucket was declared. Naming a bucket that does
+                not exist is a typo, and creating one silently is how a project
+                ends up writing to somewhere nothing reads.
+        """
+        wanted = name or self.default
+
+        if not wanted:
+            raise KeyError("no bucket named, and no default configured")
+
+        if wanted not in self.buckets:
+            known = ", ".join(sorted(self.buckets)) or "none"
+            raise KeyError(f"no bucket {wanted!r}. Configured: {known}")
+
+        return self.buckets[wanted]

--- a/sillo/storage/drivers/__init__.py
+++ b/sillo/storage/drivers/__init__.py
@@ -1,0 +1,15 @@
+"""
+sillo.storage.drivers — the backends.
+
+``memory`` and ``local`` ship in the core; ``s3`` arrives with the
+``sillo[storage-s3]`` extra. A project needing something else writes a
+:class:`~sillo.storage.base.Driver` subclass and runs it against the same
+contract suite the shipped ones are held to.
+"""
+
+from __future__ import annotations
+
+from .local import LocalDriver
+from .memory import MemoryDriver
+
+__all__ = ["LocalDriver", "MemoryDriver"]

--- a/sillo/storage/drivers/local.py
+++ b/sillo/storage/drivers/local.py
@@ -1,0 +1,452 @@
+"""
+sillo.storage.drivers.local — objects as files, contained by resolution.
+
+The driver a project starts with, and the one that has to be paranoid: a key
+arrives from outside and becomes a path.  Containment is checked by resolving
+and comparing against the root — never by looking for ``..`` in the input, which
+misses encodings, misses symlinks, and misses whatever is invented next.
+
+Writes go to a temporary file in the same directory and are renamed into place.
+On a POSIX filesystem that rename is atomic, so a reader never sees a half-
+written object and a crash mid-upload leaves the previous version intact rather
+than a truncated one.  Object storage gets this property for free; a filesystem
+has to be asked for it.
+"""
+
+from __future__ import annotations
+
+import os
+import time
+from collections.abc import AsyncIterator
+from pathlib import Path
+
+import anyio
+
+from ..base import Driver, FileInfo, Page, Stored
+from ..errors import FileNotFound
+from ..paths import contain
+from ..signing import SignedGrant, Signer
+
+__all__ = ["LocalDriver"]
+
+#: How much is read from disk at a time.
+CHUNK = 64 * 1024
+
+#: Where a content type is remembered.
+#:
+#: A filesystem has nowhere to put it — there is no metadata slot on a file —
+#: so it lives in an extended attribute where the platform has them and in a
+#: sidecar where it does not. The sniffed type must survive a restart; deciding
+#: it again on read would mean reading the file to serve the file.
+XATTR = "user.sillo.content_type"
+
+
+class LocalDriver(Driver):
+    """Objects stored as files under one directory.
+
+    Attributes:
+        root: The bucket's directory.
+        base_url: Where the serving route is mounted, for signed URLs.
+    """
+
+    name = "local"
+
+    def __init__(
+        self,
+        root: str | Path,
+        *,
+        signer: Signer | None = None,
+        base_url: str = "",
+    ) -> None:
+        """Build the driver.
+
+        Args:
+            root: The directory to store under. Created if absent.
+            signer: What mints signed URLs. Without one the driver works and
+                cannot sign, and says so when asked.
+            base_url: Where the serving route is mounted.
+        """
+        super().__init__()
+        self.root = Path(root)
+        self.root.mkdir(parents=True, exist_ok=True)
+        self.base_url = base_url.rstrip("/")
+        self._signer = signer
+
+    def _path(self, key: str) -> Path:
+        """Where a key lives.
+
+        Args:
+            key: A normalised key.
+
+        Returns:
+            The absolute path.
+
+        Raises:
+            UnsafeKey: If it resolves outside the root.
+        """
+        return contain(self.root, key)
+
+    async def write(
+        self,
+        key: str,
+        stream: AsyncIterator[bytes],
+        *,
+        content_type: str = "",
+        declared_type: str = "",
+    ) -> Stored:
+        """Write an object atomically.
+
+        Args:
+            key: Where to put it.
+            stream: The content.
+            content_type: What to serve it as.
+            declared_type: What the uploader claimed.
+
+        Returns:
+            What was written.
+        """
+        target = self._path(key)
+        target.parent.mkdir(parents=True, exist_ok=True)
+
+        # Beside the target, not in /tmp: a rename across filesystems is a copy,
+        # and a copy is not atomic.
+        staging = target.with_name(f".{target.name}.{os.getpid()}.partial")
+
+        written = 0
+        try:
+            async with await anyio.open_file(staging, "wb") as handle:
+                async for chunk in stream:
+                    await handle.write(chunk)
+                    written += len(chunk)
+
+            resolved = content_type or "application/octet-stream"
+
+            # The extended attribute goes on the staging file, so it arrives
+            # with the rename. The sidecar is named for the *target*, because
+            # the staging name is about to stop existing — naming it for the
+            # staging file is why the first version lost every content type on
+            # any filesystem without xattrs, which is all of macOS.
+            _remember_type(staging, target, resolved)
+            staging.replace(target)
+        except BaseException:
+            staging.unlink(missing_ok=True)
+            raise
+
+        return Stored(key, written, resolved, _etag(target))
+
+    async def read(self, key: str) -> AsyncIterator[bytes]:
+        """Stream an object back.
+
+        Args:
+            key: The object's key.
+
+        Yields:
+            The content, in chunks.
+
+        Raises:
+            FileNotFound: If there is no such object.
+        """
+        path = self._path(key)
+
+        if not path.is_file():
+            raise FileNotFound(key)
+
+        async with await anyio.open_file(path, "rb") as handle:
+            while True:
+                chunk = await handle.read(CHUNK)
+                if not chunk:
+                    break
+                yield chunk
+
+    async def stat(self, key: str) -> FileInfo:
+        """Describe one object.
+
+        Args:
+            key: The object's key.
+
+        Returns:
+            What is known about it.
+
+        Raises:
+            FileNotFound: If there is no such object.
+        """
+        path = self._path(key)
+
+        if not path.is_file():
+            raise FileNotFound(key)
+
+        stat = path.stat()
+
+        return FileInfo(
+            key=key,
+            size=stat.st_size,
+            content_type=_recall_type(path),
+            modified=stat.st_mtime,
+            etag=_etag(path),
+        )
+
+    async def delete(self, key: str) -> bool:
+        """Remove one object, and any directory it emptied.
+
+        Args:
+            key: The object's key.
+
+        Returns:
+            Whether anything was removed.
+        """
+        path = self._path(key)
+
+        if not path.is_file():
+            return False
+
+        path.unlink()
+        _forget_type(path)
+        _prune(path.parent, self.root.resolve())
+
+        return True
+
+    async def page(
+        self, prefix: str = "", *, cursor: str = "", limit: int = 100
+    ) -> Page:
+        """List one page of objects.
+
+        Args:
+            prefix: Only keys starting with this.
+            cursor: Where to resume.
+            limit: Most objects to return.
+
+        Returns:
+            The page.
+        """
+        root = self.root.resolve()
+        keys = sorted(
+            str(path.relative_to(root))
+            for path in root.rglob("*")
+            if path.is_file() and not path.name.startswith(".")
+        )
+
+        keys = [key for key in keys if key.startswith(prefix)]
+        if cursor:
+            keys = [key for key in keys if key > cursor]
+
+        window = keys[:limit]
+        following = keys[limit : limit + 1]
+
+        # A loop, not a generator expression: `tuple(await ... for ...)` builds
+        # an async generator and hands it to tuple(), which cannot iterate it.
+        files = []
+        for key in window:
+            files.append(await self.stat(key))
+
+        return Page(
+            files=tuple(files),
+            prefixes=_prefixes(keys, prefix),
+            cursor=window[-1] if following and window else "",
+        )
+
+    def signed_url(
+        self,
+        key: str,
+        *,
+        method: str = "GET",
+        expires_in: int = 300,
+        content_type: str = "",
+        max_bytes: int = 0,
+    ) -> str:
+        """A URL the serving route will honour.
+
+        Args:
+            key: The object's key.
+            method: The single permitted method.
+            expires_in: Seconds until it stops working.
+            content_type: The single permitted content type.
+            max_bytes: The largest permitted body.
+
+        Returns:
+            The URL.
+
+        Raises:
+            NotImplementedError: If the driver was built without a signer.
+        """
+        if self._signer is None:
+            raise NotImplementedError(
+                "this LocalDriver has no signer. setup_storage() gives one to "
+                "every bucket; a hand-built driver needs Signer(secret)."
+            )
+
+        token = self._signer.sign(
+            SignedGrant(
+                key=key,
+                method=method,
+                expires=time.time() + expires_in,
+                content_type=content_type,
+                max_bytes=max_bytes,
+            )
+        )
+
+        return f"{self.base_url}/{key}?token={token}"
+
+    async def capabilities(self) -> dict[str, object]:
+        """What this driver can do here.
+
+        Returns:
+            Capability names to values.
+        """
+        found = await super().capabilities()
+        found.update(
+            {
+                "signed_urls": self._signer is not None,
+                "atomic_write": True,
+                "content_type_metadata": _xattrs_work(self.root),
+            }
+        )
+        return found
+
+    async def close(self) -> None:
+        """Nothing to release."""
+
+
+def _etag(path: Path) -> str:
+    """A cheap version marker.
+
+    Size and modification time rather than a hash of the content: hashing means
+    reading the whole file, and an etag is wanted on every ``stat``.
+
+    Args:
+        path: The file.
+
+    Returns:
+        The marker.
+    """
+    stat = path.stat()
+    return f"{stat.st_size:x}-{int(stat.st_mtime_ns):x}"
+
+
+def _remember_type(staging: Path, target: Path, content_type: str) -> None:
+    """Record a file's content type.
+
+    Args:
+        staging: The file as written, before the rename.
+        target: Where it is about to land, which is what a sidecar is named
+            for — the staging name is about to stop existing.
+        content_type: What it will be served as.
+    """
+    try:
+        os.setxattr(staging, XATTR, content_type.encode())  # type: ignore[attr-defined]
+        return
+    except (AttributeError, OSError):
+        # No extended attributes here — a different filesystem, or a platform
+        # without them at all, which includes macOS. A sidecar is uglier and
+        # works everywhere.
+        pass
+
+    _sidecar(target).write_text(content_type, encoding="utf-8")
+
+
+def _recall_type(path: Path) -> str:
+    """Read back a file's content type.
+
+    Args:
+        path: The file.
+
+    Returns:
+        What it was stored as, or the neutral fallback.
+    """
+    try:
+        return os.getxattr(path, XATTR).decode()  # type: ignore[attr-defined]
+    except (AttributeError, OSError):
+        pass
+
+    sidecar = _sidecar(path)
+    if sidecar.is_file():
+        return sidecar.read_text(encoding="utf-8").strip()
+
+    return "application/octet-stream"
+
+
+def _forget_type(path: Path) -> None:
+    """Remove any sidecar left beside a deleted file.
+
+    Args:
+        path: The file that was deleted.
+    """
+    _sidecar(path).unlink(missing_ok=True)
+
+
+def _sidecar(path: Path) -> Path:
+    """Where a file's type is written when the filesystem cannot hold it.
+
+    Dot-prefixed so that :meth:`LocalDriver.page` skips it — a sidecar is not
+    an object and must never appear in a listing.
+
+    Args:
+        path: The file.
+
+    Returns:
+        The sidecar's path.
+    """
+    return path.with_name(f".{path.name}.type")
+
+
+def _xattrs_work(root: Path) -> bool:
+    """Whether this filesystem holds extended attributes.
+
+    Args:
+        root: The bucket's directory.
+
+    Returns:
+        True when they work here.
+    """
+    probe = root / ".sillo-xattr-probe"
+    try:
+        probe.touch()
+        os.setxattr(probe, XATTR, b"probe")  # type: ignore[attr-defined]
+        return True
+    except (AttributeError, OSError):
+        return False
+    finally:
+        probe.unlink(missing_ok=True)
+
+
+def _prune(directory: Path, root: Path) -> None:
+    """Remove directories a delete left empty.
+
+    Object storage has no directories, so a local bucket that accumulates empty
+    ones diverges from every other backend in its listings.
+
+    Args:
+        directory: Where the deleted file was.
+        root: The bucket's directory, which is never removed.
+    """
+    current = directory.resolve()
+
+    while current != root and root in current.parents:
+        try:
+            next(current.iterdir())
+            return
+        except StopIteration:
+            current.rmdir()
+            current = current.parent
+        except OSError:
+            return
+
+
+def _prefixes(keys: list[str], prefix: str) -> tuple[str, ...]:
+    """The pseudo-directories directly under a prefix.
+
+    Args:
+        keys: Every matching key.
+        prefix: What was asked for.
+
+    Returns:
+        The common prefixes, sorted.
+    """
+    found = set()
+
+    for key in keys:
+        rest = key[len(prefix) :]
+        head, slash, _ = rest.partition("/")
+        if slash:
+            found.add(f"{prefix}{head}/")
+
+    return tuple(sorted(found))

--- a/sillo/storage/drivers/memory.py
+++ b/sillo/storage/drivers/memory.py
@@ -1,0 +1,173 @@
+"""
+sillo.storage.drivers.memory — objects in a dictionary.
+
+Exists for the contract suite first and for users second.  Every assertion the
+suite makes runs against this driver, so it is the definition of what the
+contract means; a backend that disagrees with it disagrees with the contract.
+
+It is also what ``Storage.fake()`` hands you, which matters more than it looks.
+The obvious way to build a test double for storage is to point the local driver
+at a temporary directory — which is what most frameworks do, and which means an
+application's storage tests only ever exercise filesystem semantics.  Every
+difference that bites in production, starting with pagination, is invisible.
+This one pages.
+"""
+
+from __future__ import annotations
+
+import time
+from collections.abc import AsyncIterator
+
+from ..base import Driver, FileInfo, Page, Stored
+from ..errors import FileNotFound
+
+__all__ = ["MemoryDriver"]
+
+
+class MemoryDriver(Driver):
+    """Objects held in a dictionary, for tests and for small ephemera."""
+
+    name = "memory"
+
+    def __init__(self) -> None:
+        """Build an empty store."""
+        super().__init__()
+        self._objects: dict[str, tuple[bytes, FileInfo]] = {}
+
+    async def write(
+        self,
+        key: str,
+        stream: AsyncIterator[bytes],
+        *,
+        content_type: str = "",
+        declared_type: str = "",
+    ) -> Stored:
+        """Write an object.
+
+        Args:
+            key: Where to put it.
+            stream: The content.
+            content_type: What to serve it as.
+            declared_type: What the uploader claimed.
+
+        Returns:
+            What was written.
+        """
+        buffer = bytearray()
+        async for chunk in stream:
+            buffer.extend(chunk)
+
+        info = FileInfo(
+            key=key,
+            size=len(buffer),
+            content_type=content_type or "application/octet-stream",
+            modified=time.time(),
+            etag=f"{len(buffer)}-{hash(bytes(buffer)) & 0xFFFFFFFF:08x}",
+            declared_type=declared_type,
+        )
+        self._objects[key] = (bytes(buffer), info)
+
+        return Stored(key, info.size, info.content_type, info.etag)
+
+    async def read(self, key: str) -> AsyncIterator[bytes]:
+        """Stream an object back.
+
+        Args:
+            key: The object's key.
+
+        Yields:
+            The content, in one chunk.
+
+        Raises:
+            FileNotFound: If there is no such object.
+        """
+        found = self._objects.get(key)
+        if found is None:
+            raise FileNotFound(key)
+
+        yield found[0]
+
+    async def stat(self, key: str) -> FileInfo:
+        """Describe one object.
+
+        Args:
+            key: The object's key.
+
+        Returns:
+            What is known about it.
+
+        Raises:
+            FileNotFound: If there is no such object.
+        """
+        found = self._objects.get(key)
+        if found is None:
+            raise FileNotFound(key)
+
+        return found[1]
+
+    async def delete(self, key: str) -> bool:
+        """Remove one object.
+
+        Args:
+            key: The object's key.
+
+        Returns:
+            Whether anything was removed.
+        """
+        return self._objects.pop(key, None) is not None
+
+    async def page(
+        self, prefix: str = "", *, cursor: str = "", limit: int = 100
+    ) -> Page:
+        """List one page of objects.
+
+        Paginated even though a dictionary need not be, because the point of
+        this driver is to behave exactly like the contract — and a fake that is
+        more permissive than production is a fake that hides the bug it was
+        supposed to catch.
+
+        Args:
+            prefix: Only keys starting with this.
+            cursor: Where to resume.
+            limit: Most objects to return.
+
+        Returns:
+            The page.
+        """
+        keys = sorted(key for key in self._objects if key.startswith(prefix))
+        if cursor:
+            keys = [key for key in keys if key > cursor]
+
+        window = keys[:limit]
+        following = keys[limit : limit + 1]
+
+        return Page(
+            files=tuple(self._objects[key][1] for key in window),
+            prefixes=_prefixes(keys, prefix),
+            cursor=window[-1] if following and window else "",
+        )
+
+    async def close(self) -> None:
+        """Discard everything."""
+        self._objects.clear()
+
+
+def _prefixes(keys: list[str], prefix: str) -> tuple[str, ...]:
+    """The pseudo-directories directly under a prefix.
+
+    Args:
+        keys: Every matching key.
+        prefix: What was asked for.
+
+    Returns:
+        The common prefixes, sorted.
+    """
+    found = set()
+
+    for key in keys:
+        rest = key[len(prefix) :]
+        head, slash, _ = rest.partition("/")
+        if slash:
+            found.add(f"{prefix}{head}/")
+
+    return tuple(sorted(found))

--- a/sillo/storage/errors.py
+++ b/sillo/storage/errors.py
@@ -1,0 +1,74 @@
+"""
+sillo.storage.errors — what can go wrong, named.
+
+Deliberately few.  A storage layer that raises a different exception per backend
+forces every caller to know which backend it is talking to, which is the one
+thing the driver contract exists to prevent.
+"""
+
+from __future__ import annotations
+
+__all__ = [
+    "FileNotFound",
+    "PolicyRefused",
+    "SignatureInvalid",
+    "StorageError",
+    "UnsafeKey",
+]
+
+
+class StorageError(Exception):
+    """Base for everything this package raises."""
+
+
+class FileNotFound(StorageError):
+    """There is no object under that key.
+
+    Attributes:
+        key: What was asked for.
+    """
+
+    def __init__(self, key: str) -> None:
+        """Build the error.
+
+        Args:
+            key: The key that was not found.
+        """
+        super().__init__(f"no object at {key!r}")
+        self.key = key
+
+
+class UnsafeKey(StorageError):
+    """A key that would escape the bucket, or that no backend can hold.
+
+    Raised at the boundary rather than sanitised silently. A caller that meant
+    ``../../etc/passwd`` should be told, not quietly redirected somewhere else.
+    """
+
+
+class PolicyRefused(StorageError):
+    """The bucket's policy declined this operation.
+
+    Attributes:
+        action: What was attempted.
+        key: On what.
+    """
+
+    def __init__(self, action: str, key: str) -> None:
+        """Build the error.
+
+        Args:
+            action: The action refused.
+            key: The key it was refused on.
+        """
+        super().__init__(f"{action} refused on {key!r}")
+        self.action = action
+        self.key = key
+
+
+class SignatureInvalid(StorageError):
+    """A signed URL was missing, expired, tampered with, or for something else.
+
+    One error for all four on purpose.  Telling an unauthenticated caller
+    *which* of those applies tells them how the signing works.
+    """

--- a/sillo/storage/paths.py
+++ b/sillo/storage/paths.py
@@ -1,0 +1,156 @@
+"""
+sillo.storage.paths — one canonical key form, and containment by construction.
+
+Object storage has keys and filesystems have paths, and the differences are
+exactly where the bugs live.  ``a//b`` and ``a/b`` are the same file on disk and
+two different keys on S3.  ``./a`` is ``a`` on disk and a literal key beginning
+with a dot on S3.  A driver that normalises differently from its neighbour is a
+driver whose behaviour changes when a project switches backend.
+
+So every key goes through :func:`normalise` before it reaches any driver, and
+the drivers themselves never re-interpret it.
+
+Containment is checked by *resolving* and comparing, never by looking for ``..``
+in the input.  Filtering for ``..`` misses percent-encoding, misses backslashes
+on the wrong platform, misses symlinks entirely, and misses whatever is invented
+next.  Resolution is the property that actually has to hold.
+"""
+
+from __future__ import annotations
+
+import posixpath
+import unicodedata
+from pathlib import Path
+
+from .errors import UnsafeKey
+
+__all__ = ["contain", "join", "normalise", "parent", "segments"]
+
+#: The longest key any backend here will accept. S3 allows 1024 bytes; a
+#: filesystem is usually stricter per component. Refusing early keeps the two
+#: backends behaving the same.
+MAX_KEY_BYTES = 1024
+
+#: The longest single path component.
+MAX_SEGMENT = 255
+
+#: Characters no key may contain. Control characters break HTTP headers and
+#: some filesystems; a backslash is a separator on one platform and a literal
+#: on another, and a key that means two things is not a key.
+_FORBIDDEN = frozenset({"\\", "\x00"})
+
+
+def normalise(key: str) -> str:
+    """Reduce a key to the one form every driver will see.
+
+    Args:
+        key: The key as the caller wrote it.
+
+    Returns:
+        The canonical form: no leading slash, no ``.`` or ``..`` components, no
+        repeated slashes, Unicode in NFC.
+
+    Raises:
+        UnsafeKey: If the key is empty, absolute, too long, contains a
+            forbidden character, or climbs above the root.
+    """
+    if not key or not key.strip():
+        raise UnsafeKey("a key cannot be empty")
+
+    # NFC first, so that two spellings of the same name are one key. Without
+    # this a macOS upload and a Linux upload of "café.pdf" are different
+    # objects that look identical in every listing.
+    key = unicodedata.normalize("NFC", key)
+
+    if any(character in _FORBIDDEN for character in key):
+        raise UnsafeKey(f"{key!r} contains a character no key may hold")
+
+    if any(ord(character) < 32 or ord(character) == 127 for character in key):
+        raise UnsafeKey(f"{key!r} contains a control character")
+
+    if key.startswith("/"):
+        raise UnsafeKey(f"{key!r} is absolute; keys are relative to the bucket")
+
+    # posixpath rather than pathlib: a key is always slash-separated whatever
+    # the host platform does, and pathlib would helpfully reinterpret it.
+    cleaned = posixpath.normpath(key)
+
+    if cleaned in (".", "/") or cleaned.startswith("../") or cleaned == "..":
+        raise UnsafeKey(f"{key!r} climbs above the bucket")
+
+    cleaned = cleaned.lstrip("/")
+
+    if len(cleaned.encode("utf-8")) > MAX_KEY_BYTES:
+        raise UnsafeKey(f"key is longer than {MAX_KEY_BYTES} bytes")
+
+    if any(len(part.encode("utf-8")) > MAX_SEGMENT for part in cleaned.split("/")):
+        raise UnsafeKey(f"a path segment is longer than {MAX_SEGMENT} bytes")
+
+    return cleaned
+
+
+def segments(key: str) -> tuple[str, ...]:
+    """Split a normalised key into its parts.
+
+    Args:
+        key: A normalised key.
+
+    Returns:
+        The segments.
+    """
+    return tuple(part for part in key.split("/") if part)
+
+
+def parent(key: str) -> str:
+    """The prefix a key sits under.
+
+    Args:
+        key: A normalised key.
+
+    Returns:
+        Everything before the last segment, with a trailing slash, or an empty
+        string at the top level.
+    """
+    head, _, _ = key.rpartition("/")
+    return f"{head}/" if head else ""
+
+
+def join(*parts: str) -> str:
+    """Join key parts and normalise the result.
+
+    Args:
+        *parts: Key fragments.
+
+    Returns:
+        One normalised key.
+
+    Raises:
+        UnsafeKey: If the result is not a safe key.
+    """
+    return normalise("/".join(part.strip("/") for part in parts if part))
+
+
+def contain(root: Path, key: str) -> Path:
+    """Turn a key into a path inside *root*, or refuse.
+
+    The containment check is the point.  ``resolve()`` follows symlinks and
+    collapses everything, and the result either is inside the root or is not —
+    a property that holds regardless of how the input was spelled.
+
+    Args:
+        root: The bucket's directory.
+        key: A normalised key.
+
+    Returns:
+        The absolute path the key names.
+
+    Raises:
+        UnsafeKey: If the resolved path is outside *root*.
+    """
+    base = root.resolve()
+    target = (base / key).resolve()
+
+    if target != base and base not in target.parents:
+        raise UnsafeKey(f"{key!r} resolves outside the bucket")
+
+    return target

--- a/sillo/storage/policies.py
+++ b/sillo/storage/policies.py
@@ -1,0 +1,335 @@
+"""
+sillo.storage.policies — who may do what, as an object rather than a flag.
+
+Every other filesystem layer models this as visibility: ``public`` or
+``private``.  Two values cannot express the rule most applications actually
+want, which is *this user may write under their own prefix and nobody else's* —
+so every project writes that by hand, in a handler, next to the upload.  Written
+by hand it is forgotten in the second handler.
+
+A policy is asked, per operation, with the user in scope:
+
+    policy.allows(Action.WRITE, "avatars/114/face.png", user)
+
+Four are built in.  :class:`Owned` is the one that pays for the design.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Protocol, runtime_checkable
+
+from .base import Action
+
+__all__ = ["BucketPolicy", "Owned", "Private", "Public", "ReadOnly", "Signed"]
+
+
+@runtime_checkable
+class BucketPolicy(Protocol):
+    """Decides whether one operation is permitted.
+
+    A protocol rather than a base class, so a project's own policy is any
+    object with the method — including a closure over its domain model.
+    """
+
+    def allows(self, action: Action, key: str, user: Any = None) -> bool:
+        """Whether *user* may perform *action* on *key*.
+
+        Args:
+            action: What is being attempted.
+            key: The object's key, normalised.
+            user: The authenticated user, or None.
+
+        Returns:
+            True to permit.
+        """
+        ...
+
+    def signable(self, action: Action) -> bool:
+        """Whether a signed URL may grant *action* without a user.
+
+        Separate from :meth:`allows` because a signed URL is exactly the case
+        where there is no user to ask about — the permission was decided when
+        the URL was minted.
+
+        Args:
+            action: What the URL would grant.
+
+        Returns:
+            True when a signature is enough on its own.
+        """
+        ...
+
+
+class Private:
+    """Nothing is permitted without a signature.
+
+    The default, and the right default: a bucket whose contents are reachable
+    because nobody thought about it is the failure this whole module is for.
+    """
+
+    def allows(self, action: Action, key: str, user: Any = None) -> bool:
+        """Refuse everything.
+
+        Args:
+            action: Ignored.
+            key: Ignored.
+            user: Ignored.
+
+        Returns:
+            False.
+        """
+        return False
+
+    def signable(self, action: Action) -> bool:
+        """Permit anything a signature was minted for.
+
+        Args:
+            action: What the URL grants.
+
+        Returns:
+            True.
+        """
+        return True
+
+    def __repr__(self) -> str:
+        """A short description.
+
+        Returns:
+            The policy's name.
+        """
+        return "Private()"
+
+
+class Public:
+    """Anyone may read; only a signature may write.
+
+    Named for what it does rather than what it is called elsewhere.  "Public"
+    in most storage layers also means "anybody who finds the URL may overwrite
+    it", which is never what anybody meant.
+    """
+
+    def allows(self, action: Action, key: str, user: Any = None) -> bool:
+        """Permit reads and listings.
+
+        Args:
+            action: What is being attempted.
+            key: Ignored.
+            user: Ignored.
+
+        Returns:
+            True for reads and listings.
+        """
+        return action in (Action.READ, Action.LIST)
+
+    def signable(self, action: Action) -> bool:
+        """Permit anything a signature was minted for.
+
+        Args:
+            action: What the URL grants.
+
+        Returns:
+            True.
+        """
+        return True
+
+    def __repr__(self) -> str:
+        """A short description.
+
+        Returns:
+            The policy's name.
+        """
+        return "Public()"
+
+
+class ReadOnly:
+    """Any authenticated user may read; nobody may write, signed or not.
+
+    For a bucket something else fills — an export target written by a worker
+    through the driver directly, and read by people through the application.
+    """
+
+    def allows(self, action: Action, key: str, user: Any = None) -> bool:
+        """Permit reads by an authenticated user.
+
+        Args:
+            action: What is being attempted.
+            key: Ignored.
+            user: The authenticated user.
+
+        Returns:
+            True for reads and listings by somebody signed in.
+        """
+        return action in (Action.READ, Action.LIST) and _identified(user)
+
+    def signable(self, action: Action) -> bool:
+        """Permit signed reads only.
+
+        Args:
+            action: What the URL grants.
+
+        Returns:
+            True for reads.
+        """
+        return action is Action.READ
+
+    def __repr__(self) -> str:
+        """A short description.
+
+        Returns:
+            The policy's name.
+        """
+        return "ReadOnly()"
+
+
+class Signed:
+    """Only a signature, and only for reading.
+
+    Stricter than :class:`Private`, which will honour a signature for a write.
+    """
+
+    def allows(self, action: Action, key: str, user: Any = None) -> bool:
+        """Refuse everything unsigned.
+
+        Args:
+            action: Ignored.
+            key: Ignored.
+            user: Ignored.
+
+        Returns:
+            False.
+        """
+        return False
+
+    def signable(self, action: Action) -> bool:
+        """Permit signed reads only.
+
+        Args:
+            action: What the URL grants.
+
+        Returns:
+            True for reads.
+        """
+        return action is Action.READ
+
+    def __repr__(self) -> str:
+        """A short description.
+
+        Returns:
+            The policy's name.
+        """
+        return "Signed()"
+
+
+class Owned:
+    """A user may do as they like under their own prefix, and nothing outside it.
+
+    The rule most applications actually want and no visibility flag can state.
+    ``avatars/{id}/`` gives every user a private area of one shared bucket, and
+    the check happens on every operation rather than in whichever handler
+    remembered it.
+
+    Attributes:
+        prefix: A template with one placeholder, ``{id}``.
+        readable: Whether users may read each other's objects. Off by default,
+            because a shared bucket where everybody can read everything is a
+            shared bucket, not a private area.
+    """
+
+    __slots__ = ("prefix", "readable")
+
+    def __init__(self, prefix: str = "{id}/", *, readable: bool = False) -> None:
+        """Build the policy.
+
+        Args:
+            prefix: Where a user's own objects live.
+            readable: Whether users may read outside their own prefix.
+
+        Raises:
+            ValueError: If the prefix has no placeholder — which would give
+                every user the same area and quietly make the bucket shared.
+        """
+        if "{id}" not in prefix:
+            raise ValueError(
+                "an Owned prefix must contain {id}, or every user shares one area"
+            )
+
+        self.prefix = prefix
+        self.readable = readable
+
+    def allows(self, action: Action, key: str, user: Any = None) -> bool:
+        """Permit operations inside the user's own prefix.
+
+        Args:
+            action: What is being attempted.
+            key: The object's key.
+            user: The authenticated user.
+
+        Returns:
+            True when the key is the user's own, or when reading is open.
+        """
+        if not _identified(user):
+            return False
+
+        if key.startswith(self.prefix.format(id=_identity(user))):
+            return True
+
+        return self.readable and action in (Action.READ, Action.LIST)
+
+    def signable(self, action: Action) -> bool:
+        """Permit anything a signature was minted for.
+
+        Args:
+            action: What the URL grants.
+
+        Returns:
+            True. A signature for this bucket was minted by the application,
+            which had already decided whose object it was.
+        """
+        return True
+
+    def area(self, user: Any) -> str:
+        """Where one user's objects live.
+
+        Args:
+            user: The authenticated user.
+
+        Returns:
+            Their prefix.
+        """
+        return self.prefix.format(id=_identity(user))
+
+    def __repr__(self) -> str:
+        """A short description.
+
+        Returns:
+            The prefix and whether reads are open.
+        """
+        return f"Owned(prefix={self.prefix!r}, readable={self.readable})"
+
+
+def _identified(user: Any) -> bool:
+    """Whether there is a signed-in user.
+
+    Reads ``is_authenticated``, which is what sillo's ``UserBaseModel`` exposes
+    and what ``UnauthenticatedUser`` answers False to — so an anonymous request
+    carries a user object and is still correctly refused.
+
+    Args:
+        user: Whatever was in scope.
+
+    Returns:
+        True when somebody is signed in.
+    """
+    return user is not None and bool(getattr(user, "is_authenticated", False))
+
+
+def _identity(user: Any) -> str:
+    """A stable identifier for a user.
+
+    Args:
+        user: The authenticated user.
+
+    Returns:
+        Their ``identity``, ``id``, or ``str()``.
+    """
+    return str(getattr(user, "identity", None) or getattr(user, "id", None) or user)

--- a/sillo/storage/routes.py
+++ b/sillo/storage/routes.py
@@ -1,0 +1,158 @@
+"""
+sillo.storage.routes — serving what was stored, and honouring signatures.
+
+Two jobs.  It is the endpoint every local signed URL points at, and it is the
+half of content-type sniffing that makes sniffing a defence rather than a
+label: the sniffed type only matters if the browser is told not to re-sniff.
+
+So every response carries:
+
+``X-Content-Type-Options: nosniff``
+    Without it a browser will look at the bytes and reach its own conclusion,
+    and the whole sniffing chain was pointless.
+
+``Content-Disposition``
+    ``attachment`` for anything not on a small render-safe list, so an
+    unexpected type downloads rather than executing in this origin.
+
+``Content-Security-Policy: sandbox``
+    A last line under the other two, for the case where a type on the safe list
+    turns out to have been a mistake.
+
+Even so: a bucket serving files from users, on the same origin as the
+application, is a risk that headers reduce and do not remove.  A public bucket
+belongs on another origin.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+from urllib.parse import unquote
+
+from .config import StorageConfig
+from .errors import FileNotFound, PolicyRefused, SignatureInvalid, UnsafeKey
+
+__all__ = ["mount"]
+
+logger = logging.getLogger("sillo.storage")
+
+#: Types a browser may render inline. Everything else is sent as an attachment.
+#: Short and closed on purpose — this list is the blast radius.
+INLINE = frozenset(
+    {
+        "image/png",
+        "image/jpeg",
+        "image/gif",
+        "image/webp",
+        "application/pdf",
+        "text/plain",
+        "text/csv",
+    }
+)
+
+#: Headers on every response.
+GUARDS: tuple[tuple[str, str], ...] = (
+    ("x-content-type-options", "nosniff"),
+    ("content-security-policy", "sandbox; default-src 'none'"),
+    ("referrer-policy", "no-referrer"),
+    ("cross-origin-resource-policy", "same-origin"),
+)
+
+
+def mount(app: Any, storage: Any, config: StorageConfig) -> None:
+    """Register the route that serves stored objects.
+
+    Args:
+        app: The application.
+        storage: The built :class:`~sillo.storage.storage.Storage`.
+        config: What was declared.
+    """
+    route = config.route.rstrip("/")
+
+    async def serve(request, response, bucket: str, key: str):
+        """Serve one object, if the caller may have it.
+
+        Args:
+            request: The incoming request.
+            response: The responder.
+            bucket: Which bucket.
+            key: Which object.
+
+        Returns:
+            The object, or a refusal.
+        """
+        try:
+            held = storage.bucket(bucket)
+        except KeyError:
+            return response.json({"detail": "Not found"}, status_code=404)
+
+        signed = False
+        token = (
+            request.query_params.get("token")
+            if hasattr(request, "query_params")
+            else None
+        )
+
+        if token:
+            try:
+                held.driver._signer.verify(token, key=key, method="GET")
+                signed = True
+            except (SignatureInvalid, AttributeError):
+                return response.json({"detail": "Not found"}, status_code=404)
+
+        try:
+            info = await held.stat(key, user=_user(request), signed=signed)
+        except (FileNotFound, UnsafeKey):
+            # One answer for "no such object" and "not yours". A 403 on a
+            # private bucket confirms the object exists, which is half of what
+            # somebody probing for it wants to know.
+            return response.json({"detail": "Not found"}, status_code=404)
+        except PolicyRefused:
+            return response.json({"detail": "Not found"}, status_code=404)
+
+        disposition = "inline" if info.content_type in INLINE else "attachment"
+        filename = key.rsplit("/", 1)[-1]
+
+        headers = {
+            "content-type": info.content_type,
+            "content-length": str(info.size),
+            "etag": f'"{info.etag}"',
+            "content-disposition": f'{disposition}; filename="{_quote(filename)}"',
+            "cache-control": "private, max-age=0, must-revalidate",
+            **dict(GUARDS),
+        }
+
+        return response.stream(
+            held.get(key, user=_user(request), signed=signed), headers=headers
+        )
+
+    app.get(f"{route}/{{bucket}}/{{key:path}}", handler=serve, name="storage.serve")
+
+
+def _user(request: Any) -> Any:
+    """Who is asking.
+
+    Args:
+        request: The incoming request.
+
+    Returns:
+        The authenticated user, or None.
+    """
+    return getattr(request, "user", None)
+
+
+def _quote(filename: str) -> str:
+    """Make a filename safe to put in a header.
+
+    A quote or a newline in a ``Content-Disposition`` is header injection, and
+    the filename came from whoever uploaded the file.
+
+    Args:
+        filename: The object's last segment.
+
+    Returns:
+        Something safe between quotes.
+    """
+    cleaned = unquote(filename).replace("\\", "").replace('"', "")
+    return "".join(character for character in cleaned if character.isprintable())

--- a/sillo/storage/signing.py
+++ b/sillo/storage/signing.py
@@ -1,0 +1,277 @@
+"""
+sillo.storage.signing — a URL that grants one narrow permission for a while.
+
+S3 can sign; local disk cannot.  Rather than admit a hole in the contract — and
+put a branch in every project that might one day switch backend — the framework
+signs for local itself, and :mod:`sillo.storage.routes` mounts one route that
+verifies.
+
+What is signed is the whole permission, not just the key:
+
+    key · method · expiry · content type · maximum size
+
+All five, because each one left out is a permission accidentally granted.  A
+signature over the key alone is a URL that reads *and* overwrites.  One without
+the content type lets an uploader who was handed a slot for ``image/png`` store
+HTML in it.  One without a size limit lets them store a hundred gigabytes.
+
+The token is opaque and carries its own claims, so verification needs no lookup
+and no shared state — the same reason sillo-oauth derives its PKCE verifier
+instead of storing it.
+
+Comparison is constant-time.  Not because a timing attack on a development
+file server is likely, but because ``==`` on a secret is the kind of thing that
+gets copied into somewhere it matters.
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import hmac
+import json
+import time
+
+from .errors import SignatureInvalid
+
+__all__ = ["SignedGrant", "Signer"]
+
+#: Bumped if the claim set ever changes, so an old token cannot be replayed
+#: against a new interpretation of its fields.
+VERSION = "v1"
+
+
+class SignedGrant:
+    """What a signature permits.
+
+    Attributes:
+        key: The one object.
+        method: The one HTTP method.
+        expires: Unix timestamp after which it is refused.
+        content_type: The one content type a write may carry, or empty for any.
+        max_bytes: The largest body a write may carry, or zero for unlimited.
+    """
+
+    __slots__ = ("content_type", "expires", "key", "max_bytes", "method")
+
+    def __init__(
+        self,
+        key: str,
+        method: str,
+        expires: float,
+        content_type: str = "",
+        max_bytes: int = 0,
+    ) -> None:
+        """Build a grant.
+
+        Args:
+            key: The object's key.
+            method: The permitted method.
+            expires: When it stops working.
+            content_type: The permitted content type.
+            max_bytes: The permitted body size.
+        """
+        self.key = key
+        self.method = method.upper()
+        self.expires = expires
+        self.content_type = content_type
+        self.max_bytes = max_bytes
+
+    @property
+    def expired(self) -> bool:
+        """Whether the grant has run out.
+
+        Returns:
+            True when the expiry has passed.
+        """
+        return time.time() > self.expires
+
+    def claims(self) -> dict[str, object]:
+        """The grant as the data that gets signed.
+
+        Returns:
+            The claims, in a fixed key order so the same grant always produces
+            the same bytes.
+        """
+        return {
+            "v": VERSION,
+            "k": self.key,
+            "m": self.method,
+            "e": int(self.expires),
+            "c": self.content_type,
+            "s": self.max_bytes,
+        }
+
+    def __repr__(self) -> str:
+        """A short description for debugging.
+
+        Returns:
+            What it permits, without the signature.
+        """
+        return (
+            f"SignedGrant({self.method} {self.key!r}, "
+            f"expires_in={int(self.expires - time.time())}s)"
+        )
+
+
+class Signer:
+    """Mints and checks signed grants.
+
+    Attributes:
+        namespace: Mixed into the key material, so a token minted for one
+            bucket cannot be presented to another even under the same secret.
+    """
+
+    __slots__ = ("_key", "namespace")
+
+    def __init__(self, secret: str | bytes, namespace: str = "") -> None:
+        """Build a signer.
+
+        Args:
+            secret: The application secret.
+            namespace: Usually the bucket's name.
+
+        Raises:
+            ValueError: If the secret is empty or obviously too short to be
+                one. Failing here is the point: a signer built with ``""``
+                would mint tokens anybody could forge, and would do it
+                silently.
+        """
+        material = secret.encode() if isinstance(secret, str) else secret
+
+        if len(material) < 16:
+            raise ValueError(
+                "a signing secret must be at least 16 bytes; this one is "
+                f"{len(material)}"
+            )
+
+        self.namespace = namespace
+        # Derived rather than used directly, so the application secret is not
+        # the key for anything else that might also use HMAC-SHA256.
+        self._key = hmac.new(
+            material, f"sillo-storage/{VERSION}/{namespace}".encode(), hashlib.sha256
+        ).digest()
+
+    def sign(self, grant: SignedGrant) -> str:
+        """Mint a token for a grant.
+
+        Args:
+            grant: What to permit.
+
+        Returns:
+            An opaque token, safe in a URL.
+        """
+        payload = _encode(grant.claims())
+        return f"{payload}.{self._mac(payload)}"
+
+    def verify(self, token: str, *, key: str, method: str) -> SignedGrant:
+        """Check a token, and say what it permits.
+
+        Args:
+            token: The token from the URL.
+            key: The object actually being reached for.
+            method: The method actually being used.
+
+        Returns:
+            The grant, when it is valid for this request.
+
+        Raises:
+            SignatureInvalid: If the token is malformed, forged, expired, or
+                was minted for a different object or method. One error for all
+                of them: telling an unauthenticated caller *which* applies
+                tells them how the signing works.
+        """
+        payload, _, mac = token.partition(".")
+
+        if not payload or not mac:
+            raise SignatureInvalid("malformed token")
+
+        # Before anything is decoded. A forged payload should never be parsed,
+        # let alone acted on.
+        if not hmac.compare_digest(mac, self._mac(payload)):
+            raise SignatureInvalid("bad signature")
+
+        try:
+            claims = _decode(payload)
+        except Exception as error:
+            raise SignatureInvalid("malformed token") from error
+
+        if claims.get("v") != VERSION:
+            raise SignatureInvalid("bad signature")
+
+        # str() around the numbers as well: the claims came off the wire, and
+        # `float(some_dict)` is a TypeError rather than a refusal — a forged
+        # payload should be rejected, not crash the verifier.
+        try:
+            grant = SignedGrant(
+                key=str(claims.get("k", "")),
+                method=str(claims.get("m", "")),
+                expires=float(str(claims.get("e", 0))),
+                content_type=str(claims.get("c", "")),
+                max_bytes=int(str(claims.get("s", 0))),
+            )
+        except (TypeError, ValueError) as error:
+            raise SignatureInvalid("malformed token") from error
+
+        if grant.expired:
+            raise SignatureInvalid("bad signature")
+
+        # The token is genuine; it may still be for something else. Binding the
+        # grant to the request is what stops a read token being replayed as a
+        # write, or against another object.
+        if grant.key != key or grant.method != method.upper():
+            raise SignatureInvalid("bad signature")
+
+        return grant
+
+    def _mac(self, payload: str) -> str:
+        """The signature over an encoded payload.
+
+        Args:
+            payload: The encoded claims.
+
+        Returns:
+            The MAC, base64url without padding.
+        """
+        digest = hmac.new(self._key, payload.encode(), hashlib.sha256).digest()
+        return base64.urlsafe_b64encode(digest).decode().rstrip("=")
+
+    def __repr__(self) -> str:
+        """A description that does not include the key.
+
+        Returns:
+            The namespace only.
+        """
+        return f"Signer(namespace={self.namespace!r})"
+
+
+def _encode(claims: dict[str, object]) -> str:
+    """Encode claims for a URL.
+
+    Args:
+        claims: The claim set.
+
+    Returns:
+        base64url without padding.
+    """
+    raw = json.dumps(claims, separators=(",", ":"), sort_keys=True).encode()
+    return base64.urlsafe_b64encode(raw).decode().rstrip("=")
+
+
+def _decode(payload: str) -> dict[str, object]:
+    """Decode claims from a URL.
+
+    Args:
+        payload: The encoded claims.
+
+    Returns:
+        The claim set.
+    """
+    padding = "=" * (-len(payload) % 4)
+    raw = base64.urlsafe_b64decode(payload + padding)
+    decoded = json.loads(raw)
+
+    if not isinstance(decoded, dict):
+        raise ValueError("claims are not an object")
+
+    return decoded

--- a/sillo/storage/sniff.py
+++ b/sillo/storage/sniff.py
@@ -1,0 +1,205 @@
+"""
+sillo.storage.sniff — decide what a file is from what is in it.
+
+The declared type is not evidence.  ``Content-Type`` on an upload is a string
+the uploader chose, and the interesting case is not a mistake — it is a file
+whose bytes are HTML and whose declared type is ``image/png``.  Serve that
+inline from your own origin and you have stored cross-site scripting.
+
+So the sniffer decides, the declared type is recorded for comparison and never
+used to serve, and the pairing is completed on the way out by
+:mod:`sillo.storage.routes`, which sends ``X-Content-Type-Options: nosniff`` and
+a ``Content-Disposition`` on everything.  Sniffing without those headers is
+half a defence: the browser will re-sniff and reach its own conclusion.
+
+Magic numbers rather than :mod:`mimetypes`, because ``mimetypes`` reads the
+*extension*, which is the same string the uploader chose.
+
+The table is short on purpose.  It covers what applications actually accept —
+images, documents, archives, media — and anything unrecognised becomes
+``application/octet-stream``, which browsers download rather than render.
+Unknown falling back to "download it" is the safe direction.
+"""
+
+from __future__ import annotations
+
+__all__ = ["FALLBACK", "PROBE_BYTES", "looks_textual", "sniff"]
+
+#: What an unrecognised file is served as. Browsers download this rather than
+#: rendering it, which is the right default for something we cannot identify.
+FALLBACK = "application/octet-stream"
+
+#: How much of the file the sniffer needs. Every signature below sits within
+#: the first few dozen bytes; 4 kB is generous and is one read.
+PROBE_BYTES = 4096
+
+#: Offset, signature, content type. Ordered longest-first within each family so
+#: a more specific match is found before a shorter one that would also match.
+_SIGNATURES: tuple[tuple[int, bytes, str], ...] = (
+    (0, b"\x89PNG\r\n\x1a\n", "image/png"),
+    (0, b"\xff\xd8\xff", "image/jpeg"),
+    (0, b"GIF89a", "image/gif"),
+    (0, b"GIF87a", "image/gif"),
+    (0, b"BM", "image/bmp"),
+    (0, b"\x00\x00\x01\x00", "image/x-icon"),
+    (0, b"%PDF-", "application/pdf"),
+    (0, b"\x1f\x8b", "application/gzip"),
+    (0, b"BZh", "application/x-bzip2"),
+    (0, b"\xfd7zXZ\x00", "application/x-xz"),
+    (0, b"7z\xbc\xaf\x27\x1c", "application/x-7z-compressed"),
+    (0, b"Rar!\x1a\x07", "application/vnd.rar"),
+    (0, b"OggS", "audio/ogg"),
+    (0, b"fLaC", "audio/flac"),
+    (0, b"ID3", "audio/mpeg"),
+    (0, b"\x1aE\xdf\xa3", "video/webm"),
+    (0, b"SQLite format 3\x00", "application/vnd.sqlite3"),
+    (0, b"\x7fELF", "application/x-executable"),
+    (0, b"\xca\xfe\xba\xbe", "application/java-vm"),
+    # RIFF and ISO-BMFF carry their real type a few bytes in.
+    (8, b"WEBP", "image/webp"),
+    (8, b"WAVE", "audio/wav"),
+    (8, b"AVI ", "video/x-msvideo"),
+    (4, b"ftyp", "video/mp4"),
+)
+
+#: Markup a browser will execute if it is allowed to render it. Checked against
+#: the *leading* bytes of anything that looks textual, because this is the
+#: family that turns a permissive content type into an incident.
+_MARKUP: tuple[tuple[bytes, str], ...] = (
+    (b"<!doctype html", "text/html"),
+    (b"<html", "text/html"),
+    (b"<head", "text/html"),
+    (b"<body", "text/html"),
+    (b"<script", "text/html"),
+    (b"<svg", "image/svg+xml"),
+    (b"<?xml", "application/xml"),
+)
+
+#: Control characters that never appear in text a browser would render as
+#: text. Tab, newline, carriage return and escape are deliberately absent.
+_CONTROL = frozenset(bytes(range(9)) + bytes(range(14, 27)) + bytes(range(28, 32)))
+
+
+def sniff(head: bytes, *, declared: str = "", key: str = "") -> str:
+    """Decide what to serve a file as.
+
+    Args:
+        head: The first :data:`PROBE_BYTES` of the file, or all of it if it is
+            shorter.
+        declared: What the uploader claimed. Used only to break ties between
+            two readings the sniffer considers equally safe — never to override
+            what the bytes say.
+        key: The object's key. Used only for the same tie-break, and only for
+            types that cannot be told apart by content.
+
+    Returns:
+        The content type to store and serve.
+    """
+    if not head:
+        # An empty file is not a threat and not a format. Calling it text would
+        # be a guess; octet-stream is the honest answer.
+        return FALLBACK
+
+    for offset, signature, kind in _SIGNATURES:
+        if head[offset : offset + len(signature)] == signature:
+            return kind
+
+    if b"\x00" in head[:512] or _has_binary(head[:512]):
+        return FALLBACK
+
+    # Textual. Markup first, because that is the family that matters: a file
+    # beginning `<script>` is HTML however it was named or declared.
+    lowered = head[:512].lstrip().lower()
+    for prefix, kind in _MARKUP:
+        if lowered.startswith(prefix):
+            return kind
+
+    return _textual(declared, key)
+
+
+def _has_binary(head: bytes) -> bool:
+    """Whether a run of bytes is not plausibly text.
+
+    Two checks, and the second is the one that matters. A control character is
+    conclusive. Beyond that, text has to *decode*: ``\xde\xad\xbe\xef`` contains
+    no control characters and is not UTF-8, and a byte-set check alone called it
+    text and served it as ``text/plain``.
+
+    Args:
+        head: Leading bytes.
+
+    Returns:
+        True when the content is not plausibly text.
+    """
+    if any(byte in _CONTROL for byte in head):
+        return True
+
+    try:
+        head.decode("utf-8")
+    except UnicodeDecodeError as error:
+        # A probe cuts the file at a fixed offset, which can land in the middle
+        # of a multi-byte character. A failure in the last few bytes is that,
+        # not binary content.
+        return error.start < len(head) - 4
+
+    return False
+
+
+def _textual(declared: str, key: str) -> str:
+    """Name a textual file that carried no recognisable signature.
+
+    This is the one place the declared type is consulted, and it can only ever
+    choose between types that are all textual and none of which a browser will
+    execute — so the worst outcome is a ``.csv`` served as ``text/plain``.
+
+    Args:
+        declared: What the uploader claimed.
+        key: The object's key.
+
+    Returns:
+        A textual content type.
+    """
+    safe = {
+        "text/plain",
+        "text/csv",
+        "text/markdown",
+        "text/tab-separated-values",
+        "application/json",
+        "application/x-ndjson",
+        "text/calendar",
+        "text/vcard",
+    }
+
+    claim = declared.split(";", 1)[0].strip().lower()
+    if claim in safe:
+        return claim
+
+    suffix = key.rsplit(".", 1)[-1].lower() if "." in key else ""
+    return {
+        "csv": "text/csv",
+        "md": "text/markdown",
+        "markdown": "text/markdown",
+        "json": "application/json",
+        "ndjson": "application/x-ndjson",
+        "tsv": "text/tab-separated-values",
+        "ics": "text/calendar",
+        "vcf": "text/vcard",
+    }.get(suffix, "text/plain")
+
+
+def looks_textual(content_type: str) -> bool:
+    """Whether a type is one a browser renders as text.
+
+    Used by the serving route to decide whether a charset is worth stating.
+
+    Args:
+        content_type: The content type.
+
+    Returns:
+        True for text and the textual application types.
+    """
+    return content_type.startswith("text/") or content_type in {
+        "application/json",
+        "application/xml",
+        "application/x-ndjson",
+    }

--- a/sillo/storage/storage.py
+++ b/sillo/storage/storage.py
@@ -1,0 +1,189 @@
+"""
+sillo.storage.storage — the object on ``app.state``, and how it gets there.
+
+``setup_storage(app, config)`` follows ``setup_record``: build the thing, put it
+on ``app.state``, register the lifecycle hooks, return it.  A project holds the
+:class:`Storage` and asks it for buckets.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from .bucket import Bucket
+from .config import BucketConfig, StorageConfig
+from .drivers import LocalDriver, MemoryDriver
+from .policies import Private
+from .signing import Signer
+
+__all__ = ["Storage", "setup_storage"]
+
+logger = logging.getLogger("sillo.storage")
+
+
+class Storage:
+    """Every bucket a project declared.
+
+    Attributes:
+        config: What was declared.
+        buckets: The built buckets, by name.
+    """
+
+    __slots__ = ("buckets", "config")
+
+    def __init__(self, config: StorageConfig, *, secret: str = "") -> None:
+        """Build the buckets a configuration describes.
+
+        Args:
+            config: What was declared.
+            secret: What signs URLs, when the configuration did not say.
+
+        Raises:
+            ValueError: If a bucket names a driver that does not exist.
+        """
+        self.config = config
+        self.buckets: dict[str, Bucket] = {}
+
+        signing_secret = config.secret or secret
+
+        for name, settings in config.buckets.items():
+            self.buckets[name] = Bucket(
+                name,
+                _build(name, settings, signing_secret, config.route),
+                policy=settings.policy or Private(),
+                max_bytes=settings.max_bytes,
+                accepts=settings.accepts,
+            )
+
+    def bucket(self, name: str = "") -> Bucket:
+        """One bucket.
+
+        Args:
+            name: Its name, or empty for the default.
+
+        Returns:
+            The bucket.
+
+        Raises:
+            KeyError: If no such bucket was declared.
+        """
+        wanted = name or self.config.default
+        self.config.bucket(wanted)
+        return self.buckets[wanted]
+
+    def listen(self, listener: Any) -> Any:
+        """Be told about every operation, in every bucket.
+
+        Args:
+            listener: Called with each
+                :class:`~sillo.storage.base.StorageEvent`.
+
+        Returns:
+            The listener, so this can be used as a decorator.
+        """
+        for bucket in self.buckets.values():
+            bucket.driver.listen(listener)
+        return listener
+
+    async def close(self) -> None:
+        """Release every driver."""
+        for bucket in self.buckets.values():
+            await bucket.driver.close()
+
+    def __repr__(self) -> str:
+        """A short description for debugging.
+
+        Returns:
+            The bucket names.
+        """
+        return f"Storage({', '.join(sorted(self.buckets)) or 'no buckets'})"
+
+
+def _build(name: str, settings: BucketConfig, secret: str, route: str) -> Any:
+    """Construct the driver a bucket asked for.
+
+    Args:
+        name: The bucket's name.
+        settings: Its configuration.
+        secret: What signs URLs.
+        route: Where the serving route is mounted.
+
+    Returns:
+        The driver.
+
+    Raises:
+        ValueError: If the driver is unknown, or cannot be built as asked.
+    """
+    signer = Signer(secret, name) if secret else None
+
+    if settings.driver == "memory":
+        return MemoryDriver()
+
+    if settings.driver == "local":
+        if not settings.root:
+            raise ValueError(f"bucket {name!r} uses the local driver and has no root")
+
+        return LocalDriver(
+            settings.root, signer=signer, base_url=f"{route.rstrip('/')}/{name}"
+        )
+
+    if settings.driver == "s3":
+        raise ValueError(
+            f"bucket {name!r} asks for the s3 driver, which needs "
+            "sillo-framework[storage-s3]"
+        )
+
+    raise ValueError(
+        f"bucket {name!r} asks for an unknown driver {settings.driver!r}. "
+        "Known: memory, local, s3."
+    )
+
+
+def setup_storage(app: Any, config: StorageConfig, *, secret: str = "") -> Storage:
+    """Wire storage into an application.
+
+    Puts the :class:`Storage` on ``app.state["storage"]``, mounts the serving
+    route when one is wanted, and registers a shutdown hook.
+
+    Args:
+        app: The application.
+        config: What to build.
+        secret: What signs URLs, when the configuration did not say. Falls back
+            to the application's own secret.
+
+    Returns:
+        The storage.
+    """
+    if "storage" in app.state:
+        return app.state["storage"]
+
+    storage = Storage(config, secret=secret or _app_secret(app))
+    app.state["storage"] = storage
+    app.on_shutdown(storage.close)
+
+    if config.serve:
+        from .routes import mount
+
+        mount(app, storage, config)
+
+    logger.debug("storage ready — %s", storage)
+    return storage
+
+
+def _app_secret(app: Any) -> str:
+    """The application's own secret, if it has one.
+
+    Args:
+        app: The application.
+
+    Returns:
+        The secret, or an empty string — in which case the buckets are built
+        without a signer and say so when asked to sign.
+    """
+    for name in ("secret_key", "secret"):
+        found = getattr(app, name, None) or (app.state or {}).get(name)
+        if found:
+            return str(found)
+
+    return ""

--- a/tests/test_storage/contract.py
+++ b/tests/test_storage/contract.py
@@ -1,0 +1,231 @@
+"""
+The driver contract, as assertions.
+
+One suite, run against every driver.  Not per-driver tests: "works locally,
+breaks on S3" is the entire failure mode of a storage layer, and this structure
+is the only one that catches it.  A backend that disagrees with anything here
+disagrees with the contract, whoever wrote it.
+
+Written before the second driver existed, on purpose.  Write it afterwards and
+the contract quietly becomes "whatever the first driver happened to do".
+
+Anybody writing a third-party driver imports :class:`DriverContract`, gives it a
+fixture, and finds out whether they are finished.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from sillo.storage.base import chunks, collect
+from sillo.storage.errors import FileNotFound
+
+
+class DriverContract:
+    """Everything a :class:`~sillo.storage.base.Driver` must do.
+
+    Subclass it and provide a ``driver`` fixture.
+    """
+
+    # -- writing and reading --------------------------------------------
+
+    async def test_what_was_written_comes_back(self, driver):
+        await driver.write("a.txt", chunks(b"hello"), content_type="text/plain")
+        assert await collect(driver.read("a.txt")) == b"hello"
+
+    async def test_an_empty_object_is_an_object(self, driver):
+        """Zero bytes is a file, not an absence."""
+        await driver.write("empty.bin", chunks(b""))
+        assert await collect(driver.read("empty.bin")) == b""
+        assert (await driver.stat("empty.bin")).size == 0
+
+    async def test_a_large_object_survives_chunking(self, driver):
+        payload = bytes(range(256)) * 8192
+        await driver.write("big.bin", chunks(payload, size=4096))
+        assert await collect(driver.read("big.bin")) == payload
+
+    async def test_writing_again_replaces(self, driver):
+        await driver.write("a.txt", chunks(b"first"))
+        await driver.write("a.txt", chunks(b"second"))
+        assert await collect(driver.read("a.txt")) == b"second"
+
+    async def test_the_content_type_is_kept(self, driver):
+        await driver.write("a.txt", chunks(b"x"), content_type="text/csv")
+        assert (await driver.stat("a.txt")).content_type == "text/csv"
+
+    async def test_the_size_is_reported(self, driver):
+        stored = await driver.write("a.txt", chunks(b"12345"))
+        assert stored.size == 5
+        assert (await driver.stat("a.txt")).size == 5
+
+    async def test_nested_keys_work(self, driver):
+        await driver.write("a/b/c/d.txt", chunks(b"deep"))
+        assert await collect(driver.read("a/b/c/d.txt")) == b"deep"
+
+    async def test_a_unicode_key_works(self, driver):
+        await driver.write("café/résumé.pdf", chunks(b"x"))
+        assert await driver.exists("café/résumé.pdf")
+
+    async def test_a_key_with_spaces_works(self, driver):
+        await driver.write("my documents/a file.txt", chunks(b"x"))
+        assert await driver.exists("my documents/a file.txt")
+
+    # -- absence --------------------------------------------------------
+
+    async def test_reading_something_absent_raises(self, driver):
+        with pytest.raises(FileNotFound):
+            await collect(driver.read("nope.txt"))
+
+    async def test_stat_of_something_absent_raises(self, driver):
+        with pytest.raises(FileNotFound):
+            await driver.stat("nope.txt")
+
+    async def test_exists_is_false_rather_than_raising(self, driver):
+        assert await driver.exists("nope.txt") is False
+
+    async def test_deleting_something_absent_is_not_an_error(self, driver):
+        """The caller wanted it gone. It is gone."""
+        assert await driver.delete("nope.txt") is False
+
+    # -- deleting -------------------------------------------------------
+
+    async def test_deleting_removes(self, driver):
+        await driver.write("a.txt", chunks(b"x"))
+        assert await driver.delete("a.txt") is True
+        assert await driver.exists("a.txt") is False
+
+    async def test_deleting_one_leaves_its_neighbours(self, driver):
+        await driver.write("a/one.txt", chunks(b"1"))
+        await driver.write("a/two.txt", chunks(b"2"))
+        await driver.delete("a/one.txt")
+        assert await driver.exists("a/two.txt")
+
+    # -- listing --------------------------------------------------------
+
+    async def test_listing_finds_what_was_written(self, driver):
+        for index in range(3):
+            await driver.write(f"a/{index}.txt", chunks(b"x"))
+
+        page = await driver.page("a/")
+        assert {info.key for info in page.files} == {"a/0.txt", "a/1.txt", "a/2.txt"}
+
+    async def test_a_prefix_excludes_everything_else(self, driver):
+        await driver.write("wanted/a.txt", chunks(b"x"))
+        await driver.write("other/b.txt", chunks(b"x"))
+
+        page = await driver.page("wanted/")
+        assert {info.key for info in page.files} == {"wanted/a.txt"}
+
+    async def test_an_empty_prefix_lists_everything(self, driver):
+        await driver.write("a.txt", chunks(b"x"))
+        await driver.write("b/c.txt", chunks(b"x"))
+        assert len((await driver.page()).files) == 2
+
+    async def test_listing_nothing_is_an_empty_page(self, driver):
+        page = await driver.page("nothing/")
+        assert page.files == () and page.more is False
+
+    async def test_a_page_respects_its_limit(self, driver):
+        for index in range(10):
+            await driver.write(f"a/{index}.txt", chunks(b"x"))
+
+        assert len((await driver.page("a/", limit=4)).files) == 4
+
+    async def test_the_cursor_reaches_the_rest(self, driver):
+        """S3 pages at a thousand keys and local disk does not. A contract that
+        returned a plain list would work in development and fall over the first
+        time a bucket grew."""
+        for index in range(10):
+            await driver.write(f"a/{index:02d}.txt", chunks(b"x"))
+
+        seen: list[str] = []
+        cursor = ""
+
+        while True:
+            page = await driver.page("a/", cursor=cursor, limit=3)
+            seen.extend(info.key for info in page.files)
+            if not page.more:
+                break
+            cursor = page.cursor
+
+        assert len(seen) == 10
+        assert len(set(seen)) == 10
+
+    async def test_paging_does_not_repeat_a_key(self, driver):
+        for index in range(7):
+            await driver.write(f"a/{index}.txt", chunks(b"x"))
+
+        first = await driver.page("a/", limit=3)
+        second = await driver.page("a/", cursor=first.cursor, limit=3)
+
+        assert not ({i.key for i in first.files} & {i.key for i in second.files})
+
+    async def test_common_prefixes_are_reported(self, driver):
+        await driver.write("a/one/x.txt", chunks(b"x"))
+        await driver.write("a/two/y.txt", chunks(b"x"))
+
+        assert set((await driver.page("a/")).prefixes) == {"a/one/", "a/two/"}
+
+    # -- copying and moving ---------------------------------------------
+
+    async def test_copying_leaves_the_original(self, driver):
+        await driver.write("a.txt", chunks(b"x"), content_type="text/plain")
+        await driver.copy("a.txt", "b.txt")
+
+        assert await driver.exists("a.txt")
+        assert await collect(driver.read("b.txt")) == b"x"
+
+    async def test_copying_keeps_the_content_type(self, driver):
+        await driver.write("a.txt", chunks(b"x"), content_type="text/csv")
+        await driver.copy("a.txt", "b.txt")
+
+        assert (await driver.stat("b.txt")).content_type == "text/csv"
+
+    async def test_moving_removes_the_original(self, driver):
+        await driver.write("a.txt", chunks(b"x"))
+        await driver.move("a.txt", "b.txt")
+
+        assert await driver.exists("a.txt") is False
+        assert await driver.exists("b.txt") is True
+
+    # -- watching -------------------------------------------------------
+
+    async def test_a_listener_hears_about_a_write(self, driver):
+        heard = []
+        driver.listen(heard.append)
+
+        from sillo.storage.base import Action, StorageEvent
+
+        await driver.emit(
+            StorageEvent(bucket="b", key="a.txt", action=Action.WRITE, driver=driver.name)
+        )
+        assert heard and heard[0].key == "a.txt"
+
+    async def test_a_listener_that_raises_cannot_break_anything(self, driver):
+        """An observer must not be able to fail a write."""
+        from sillo.storage.base import Action, StorageEvent
+
+        def explode(event):
+            raise RuntimeError("no")
+
+        driver.listen(explode)
+        await driver.emit(
+            StorageEvent(bucket="b", key="a", action=Action.READ, driver=driver.name)
+        )
+
+    async def test_unlistening_stops_delivery(self, driver):
+        from sillo.storage.base import Action, StorageEvent
+
+        heard = []
+        driver.listen(heard.append)
+        driver.unlisten(heard.append)
+
+        await driver.emit(
+            StorageEvent(bucket="b", key="a", action=Action.READ, driver=driver.name)
+        )
+        assert heard == []
+
+    # -- reporting ------------------------------------------------------
+
+    async def test_it_says_what_it_can_do(self, driver):
+        assert (await driver.capabilities())["driver"] == driver.name

--- a/tests/test_storage/test_bucket.py
+++ b/tests/test_storage/test_bucket.py
@@ -1,0 +1,296 @@
+"""
+The bucket: policy, limits, sniffing and events, around a driver.
+
+The driver's job is to move bytes. Everything here is what the bucket adds, and
+it is tested separately because a driver that also decided what a file was and
+who could have it would give every backend its own chance to decide differently.
+"""
+
+from __future__ import annotations
+
+import tracemalloc
+
+import anyio
+import pytest
+
+from sillo.storage import Bucket, MemoryDriver, Owned, Private, Public, ReadOnly
+from sillo.storage.base import Action, chunks, collect
+from sillo.storage.errors import PolicyRefused, StorageError, UnsafeKey
+
+
+class User:
+    """Somebody signed in."""
+
+    is_authenticated = True
+
+    def __init__(self, identity: str = "114") -> None:
+        self.identity = identity
+
+
+ANON = None
+
+
+@pytest.fixture
+def bucket():
+    return Bucket("attachments", MemoryDriver(), policy=Public())
+
+
+class TestPolicy:
+    async def test_a_private_bucket_refuses_a_signed_in_user(self):
+        """Private means private, not "private unless you are logged in"."""
+        held = Bucket("secret", MemoryDriver(), policy=Private())
+
+        with pytest.raises(PolicyRefused):
+            await held.put("a.txt", chunks(b"x"), user=User())
+
+    async def test_a_private_bucket_honours_a_signature(self):
+        held = Bucket("secret", MemoryDriver(), policy=Private())
+        await held.put("a.txt", chunks(b"x"), signed=True)
+
+        assert await collect(held.get("a.txt", signed=True)) == b"x"
+
+    async def test_a_private_bucket_still_refuses_the_same_read_unsigned(self):
+        """Proving the previous test measures the signature and not a bucket
+        that turned out to be readable anyway."""
+        held = Bucket("secret", MemoryDriver(), policy=Private())
+        await held.put("a.txt", chunks(b"x"), signed=True)
+
+        with pytest.raises(PolicyRefused):
+            await collect(held.get("a.txt", user=User()))
+
+    async def test_a_public_bucket_reads_without_a_user(self, bucket):
+        await bucket.put("a.txt", chunks(b"x"), signed=True)
+        assert await collect(bucket.get("a.txt", user=ANON)) == b"x"
+
+    async def test_a_public_bucket_still_refuses_an_anonymous_write(self, bucket):
+        """"Public" elsewhere also means anybody who finds the URL may
+        overwrite it, which is never what anybody meant."""
+        with pytest.raises(PolicyRefused):
+            await bucket.put("a.txt", chunks(b"x"), user=ANON)
+
+    async def test_a_read_only_bucket_refuses_every_write(self):
+        held = Bucket("exports", MemoryDriver(), policy=ReadOnly())
+
+        with pytest.raises(PolicyRefused):
+            await held.put("a.txt", chunks(b"x"), user=User())
+
+    async def test_a_read_only_bucket_refuses_a_signed_write(self):
+        held = Bucket("exports", MemoryDriver(), policy=ReadOnly())
+
+        with pytest.raises(PolicyRefused):
+            await held.put("a.txt", chunks(b"x"), signed=True)
+
+
+class TestOwned:
+    """The rule most applications actually want, and no visibility flag can
+    state."""
+
+    @pytest.fixture
+    def avatars(self):
+        return Bucket("avatars", MemoryDriver(), policy=Owned())
+
+    async def test_a_user_may_write_under_their_own_prefix(self, avatars):
+        await avatars.put("114/face.png", chunks(b"x"), user=User("114"))
+        assert await avatars.exists("114/face.png", user=User("114"))
+
+    async def test_a_user_may_not_write_under_another(self, avatars):
+        with pytest.raises(PolicyRefused):
+            await avatars.put("999/face.png", chunks(b"x"), user=User("114"))
+
+    async def test_a_user_may_not_read_another(self, avatars):
+        await avatars.put("999/face.png", chunks(b"x"), user=User("999"))
+
+        with pytest.raises(PolicyRefused):
+            await collect(avatars.get("999/face.png", user=User("114")))
+
+    async def test_an_anonymous_caller_gets_nothing(self, avatars):
+        with pytest.raises(PolicyRefused):
+            await avatars.put("114/face.png", chunks(b"x"), user=ANON)
+
+    async def test_reads_can_be_opened_without_opening_writes(self):
+        avatars = Bucket("avatars", MemoryDriver(), policy=Owned(readable=True))
+        await avatars.put("999/face.png", chunks(b"x"), user=User("999"))
+
+        assert await collect(avatars.get("999/face.png", user=User("114"))) == b"x"
+
+        with pytest.raises(PolicyRefused):
+            await avatars.put("999/face.png", chunks(b"y"), user=User("114"))
+
+
+class TestSniffingThroughTheBucket:
+    async def test_the_stored_type_is_the_sniffed_one(self, bucket):
+        await bucket.put(
+            "a.png", chunks(b"<!DOCTYPE html><script>"), content_type="image/png",
+            signed=True,
+        )
+        assert (await bucket.stat("a.png", signed=True)).content_type == "text/html"
+
+    async def test_the_declaration_is_kept_for_comparison(self, bucket):
+        await bucket.put(
+            "a.png", chunks(b"<!DOCTYPE html>"), content_type="image/png", signed=True
+        )
+        info = await bucket.stat("a.png", signed=True)
+
+        assert info.declared_type == "image/png"
+        assert info.mistyped is True
+
+    async def test_an_honest_upload_is_not_flagged(self, bucket):
+        await bucket.put(
+            "a.png", chunks(b"\x89PNG\r\n\x1a\n" + b"\x00" * 32),
+            content_type="image/png", signed=True,
+        )
+        assert (await bucket.stat("a.png", signed=True)).mistyped is False
+
+    async def test_a_bucket_can_refuse_a_type(self):
+        """Stated as what the sniffer decided, so declaring image/png and
+        uploading HTML is refused here rather than stored."""
+        images = Bucket(
+            "avatars", MemoryDriver(), policy=Public(),
+            accepts=("image/png", "image/jpeg"),
+        )
+
+        with pytest.raises(StorageError, match="does not accept"):
+            await images.put(
+                "a.png", chunks(b"<!DOCTYPE html>"), content_type="image/png",
+                signed=True,
+            )
+
+    async def test_a_bucket_accepts_what_it_said_it_would(self):
+        images = Bucket(
+            "avatars", MemoryDriver(), policy=Public(), accepts=("image/png",)
+        )
+        stored = await images.put(
+            "a.png", chunks(b"\x89PNG\r\n\x1a\n" + b"\x00" * 32), signed=True
+        )
+        assert stored.content_type == "image/png"
+
+
+class TestLimits:
+    async def test_an_oversized_object_is_refused(self):
+        small = Bucket("small", MemoryDriver(), policy=Public(), max_bytes=100)
+
+        with pytest.raises(StorageError, match="exceeds"):
+            await small.put("big.bin", chunks(b"x" * 500), signed=True)
+
+    async def test_the_limit_is_enforced_while_streaming(self):
+        """Not against a declared Content-Length, which is a number the
+        uploader chose. A body that claims one kilobyte and sends five is
+        refused at the kilobyte, having buffered none of the rest."""
+        small = Bucket("small", MemoryDriver(), policy=Public(), max_bytes=1024)
+        sent = 0
+
+        async def endless():
+            nonlocal sent
+            while True:
+                sent += 512
+                yield b"x" * 512
+
+        with pytest.raises(StorageError):
+            await small.put("big.bin", endless(), signed=True)
+
+        # The probe is capped by the bucket's own limit, so a kilobyte ceiling
+        # reads about a kilobyte and not the full four-kilobyte probe.
+        assert sent <= 2048
+
+    async def test_something_within_the_limit_is_stored(self):
+        small = Bucket("small", MemoryDriver(), policy=Public(), max_bytes=100)
+        assert (await small.put("a.bin", chunks(b"x" * 50), signed=True)).size == 50
+
+
+class TestKeysThroughTheBucket:
+    async def test_an_unsafe_key_never_reaches_the_driver(self, bucket):
+        with pytest.raises(UnsafeKey):
+            await bucket.put("../escape.txt", chunks(b"x"), signed=True)
+
+    async def test_keys_are_normalised_before_anything_else(self, bucket):
+        await bucket.put("./a//b.txt", chunks(b"x"), signed=True)
+        assert (await bucket.stat("a/b.txt", signed=True)).key == "a/b.txt"
+
+
+class TestEvents:
+    async def test_a_write_is_reported(self, bucket):
+        heard = []
+        bucket.driver.listen(heard.append)
+
+        await bucket.put("a.txt", chunks(b"hello"), signed=True)
+
+        assert [(e.action, e.key, e.size) for e in heard] == [
+            (Action.WRITE, "a.txt", 5)
+        ]
+
+    async def test_a_read_is_reported_with_what_was_sent(self, bucket):
+        await bucket.put("a.txt", chunks(b"hello"), signed=True)
+
+        heard = []
+        bucket.driver.listen(heard.append)
+        await collect(bucket.get("a.txt", signed=True))
+
+        assert heard[0].action is Action.READ and heard[0].size == 5
+
+    async def test_deleting_something_absent_is_reported_as_missing(self, bucket):
+        heard = []
+        bucket.driver.listen(heard.append)
+
+        await bucket.delete("nope.txt", signed=True)
+
+        assert heard[0].outcome == "missing"
+
+    async def test_a_refused_write_is_reported_as_an_error(self):
+        small = Bucket("small", MemoryDriver(), policy=Public(), max_bytes=10)
+        heard = []
+        small.driver.listen(heard.append)
+
+        with pytest.raises(StorageError):
+            await small.put("a.png", chunks(b"<!DOCTYPE html>" * 40), signed=True)
+
+        assert heard and heard[0].outcome == "error"
+
+    async def test_an_event_carries_a_duration(self, bucket):
+        heard = []
+        bucket.driver.listen(heard.append)
+        await bucket.put("a.txt", chunks(b"x"), signed=True)
+
+        assert heard[0].duration_ms >= 0
+
+
+class TestStreaming:
+    """The one property a normal test cannot check: everything passes whether
+    or not the file was buffered whole."""
+
+    def test_a_large_upload_does_not_grow_memory(self, tmp_path):
+        from sillo.storage import LocalDriver
+
+        megabyte = b"x" * (1024 * 1024)
+
+        async def source():
+            for _ in range(64):
+                yield megabyte
+
+        async def upload():
+            held = Bucket("big", LocalDriver(tmp_path), policy=Public())
+            await held.put("big.bin", source(), signed=True)
+
+        tracemalloc.start()
+        try:
+            anyio.run(upload)
+            _, peak = tracemalloc.get_traced_memory()
+        finally:
+            tracemalloc.stop()
+
+        # 64 MB in, and the peak must stay near the probe buffer rather than
+        # near the payload.
+        assert peak < 8 * 1024 * 1024, f"peaked at {peak / 1e6:.1f} MB"
+
+    async def test_the_stream_is_consumed_once(self, bucket):
+        """Catches the accidental `data = b"".join(stream)` somebody adds in
+        six months to make an edge case easier."""
+        reads = 0
+
+        async def counted():
+            nonlocal reads
+            for _ in range(4):
+                reads += 1
+                yield b"x" * 8
+
+        await bucket.put("a.bin", counted(), signed=True)
+        assert reads == 4

--- a/tests/test_storage/test_drivers.py
+++ b/tests/test_storage/test_drivers.py
@@ -1,0 +1,29 @@
+"""Every shipped driver, against the one contract."""
+
+from __future__ import annotations
+
+import pytest
+
+from sillo.storage.drivers import LocalDriver, MemoryDriver
+
+from .contract import DriverContract
+
+
+class TestMemoryDriver(DriverContract):
+    """The fake, which is held to exactly the contract production is."""
+
+    @pytest.fixture
+    async def driver(self):
+        built = MemoryDriver()
+        yield built
+        await built.close()
+
+
+class TestLocalDriver(DriverContract):
+    """Files on disk."""
+
+    @pytest.fixture
+    async def driver(self, tmp_path):
+        built = LocalDriver(tmp_path)
+        yield built
+        await built.close()

--- a/tests/test_storage/test_integration.py
+++ b/tests/test_storage/test_integration.py
@@ -1,0 +1,209 @@
+"""
+Storage inside a real application.
+
+The wiring is where the assumptions are: that `app.state` holds what the rest of
+the framework expects, that the lifecycle hooks fire, that the serving route
+mounts where it says. A mock application would agree with every one of those and
+prove none of them.
+"""
+
+from __future__ import annotations
+
+import pytest
+from sillo import SilloApp
+
+from sillo.storage import (
+    BucketConfig,
+    MemoryDriver,
+    Owned,
+    Public,
+    StorageConfig,
+    setup_storage,
+)
+from sillo.storage.base import chunks, collect
+
+
+SECRET = "an-application-secret-long-enough"
+
+
+@pytest.fixture
+def app(tmp_path):
+    application = SilloApp(title="Storage test")
+    application.state["secret_key"] = SECRET
+
+    setup_storage(
+        application,
+        StorageConfig(
+            default="attachments",
+            buckets={
+                "attachments": BucketConfig(
+                    driver="local", root=str(tmp_path / "attachments"), policy=Public()
+                ),
+                "avatars": BucketConfig(
+                    driver="local",
+                    root=str(tmp_path / "avatars"),
+                    policy=Owned(),
+                    accepts=("image/png",),
+                ),
+                "scratch": BucketConfig(driver="memory", policy=Public()),
+            },
+        ),
+    )
+    return application
+
+
+class TestWiring:
+    def test_it_lands_on_the_application_state(self, app):
+        assert "storage" in app.state
+
+    def test_calling_it_twice_returns_the_same_storage(self, app):
+        assert setup_storage(app, StorageConfig()) is app.state["storage"]
+
+    def test_the_default_bucket_needs_no_name(self, app):
+        assert app.state["storage"].bucket().name == "attachments"
+
+    def test_an_unknown_bucket_is_a_clear_error(self, app):
+        with pytest.raises(KeyError, match="Configured"):
+            app.state["storage"].bucket("nope")
+
+    def test_each_bucket_gets_the_driver_it_asked_for(self, app):
+        storage = app.state["storage"]
+        assert storage.bucket("scratch").driver.name == "memory"
+        assert storage.bucket("attachments").driver.name == "local"
+
+    def test_the_serving_route_is_mounted(self, app):
+        paths = {getattr(route, "raw_path", "") for route in app.get_all_routes()}
+        assert any(path.startswith("/storage/") for path in paths)
+
+    def test_a_bucket_with_no_root_is_refused_at_startup(self):
+        """Rather than at the first upload, in production, on a Friday."""
+        with pytest.raises(ValueError, match="no root"):
+            setup_storage(
+                SilloApp(title="broken"),
+                StorageConfig(buckets={"x": BucketConfig(driver="local")}),
+            )
+
+    def test_asking_for_s3_without_the_extra_says_so(self):
+        with pytest.raises(ValueError, match="storage-s3"):
+            setup_storage(
+                SilloApp(title="broken"),
+                StorageConfig(buckets={"x": BucketConfig(driver="s3", bucket="b")}),
+            )
+
+    def test_an_unknown_driver_lists_the_known_ones(self):
+        with pytest.raises(ValueError, match="memory, local, s3"):
+            setup_storage(
+                SilloApp(title="broken"),
+                StorageConfig(buckets={"x": BucketConfig(driver="ftp")}),
+            )
+
+
+class TestSignedUrls:
+    def test_a_bucket_can_mint_one(self, app):
+        url = app.state["storage"].bucket("attachments").signed_url("a.txt")
+        assert "/storage/attachments/a.txt?token=" in url
+
+    def test_the_secret_comes_from_the_application(self, app):
+        """A bucket with no signer would raise instead."""
+        assert app.state["storage"].bucket("scratch") is not None
+        app.state["storage"].bucket("attachments").signed_url("a.txt")
+
+    def test_the_url_is_bound_to_the_object(self, app):
+        bucket = app.state["storage"].bucket("attachments")
+        first = bucket.signed_url("a.txt")
+        second = bucket.signed_url("b.txt")
+
+        assert first.split("token=")[1] != second.split("token=")[1]
+
+    def test_a_write_url_carries_the_buckets_own_ceiling(self, tmp_path):
+        application = SilloApp(title="limited")
+        application.state["secret_key"] = SECRET
+        setup_storage(
+            application,
+            StorageConfig(
+                default="small",
+                buckets={
+                    "small": BucketConfig(
+                        driver="local",
+                        root=str(tmp_path / "small"),
+                        policy=Public(),
+                        max_bytes=1024,
+                    )
+                },
+            ),
+        )
+
+        bucket = application.state["storage"].bucket()
+        url = bucket.signed_url("a.bin", method="PUT")
+        token = url.split("token=")[1]
+
+        grant = bucket.driver._signer.verify(token, key="a.bin", method="PUT")
+        assert grant.max_bytes == 1024
+
+
+class TestThroughTheApplication:
+    async def test_a_round_trip(self, app):
+        bucket = app.state["storage"].bucket("scratch")
+
+        await bucket.put("notes/a.txt", chunks(b"hello"), signed=True)
+        assert await collect(bucket.get("notes/a.txt", user=None)) == b"hello"
+
+    async def test_the_avatars_bucket_enforces_its_own_rules(self, app):
+        from sillo.storage.errors import PolicyRefused, StorageError
+
+        bucket = app.state["storage"].bucket("avatars")
+
+        class User:
+            is_authenticated = True
+            identity = "114"
+
+        # Right prefix, right type.
+        await bucket.put(
+            "114/face.png",
+            chunks(b"\x89PNG\r\n\x1a\n" + b"\x00" * 32),
+            content_type="image/png",
+            user=User(),
+        )
+
+        # Right prefix, wrong content whatever it claims.
+        with pytest.raises(StorageError):
+            await bucket.put(
+                "114/evil.png",
+                chunks(b"<!DOCTYPE html><script>"),
+                content_type="image/png",
+                user=User(),
+            )
+
+        # Wrong prefix.
+        with pytest.raises(PolicyRefused):
+            await bucket.put("999/face.png", chunks(b"x"), user=User())
+
+    async def test_one_listener_sees_every_bucket(self, app):
+        heard = []
+        app.state["storage"].listen(heard.append)
+
+        await app.state["storage"].bucket("scratch").put(
+            "a.txt", chunks(b"x"), signed=True
+        )
+
+        assert [event.bucket for event in heard] == ["scratch"]
+
+    async def test_shutting_down_releases_the_drivers(self, app):
+        storage = app.state["storage"]
+        await storage.bucket("scratch").put("a.txt", chunks(b"x"), signed=True)
+        await storage.close()
+
+        assert (await storage.bucket("scratch").driver.page()).files == ()
+
+
+class TestFake:
+    """The memory driver is what a test double should be: held to exactly the
+    contract production is, rather than a local disk wearing a hat."""
+
+    async def test_it_pages_like_the_real_thing(self):
+        driver = MemoryDriver()
+        for index in range(10):
+            await driver.write(f"a/{index:02d}.txt", chunks(b"x"))
+
+        page = await driver.page("a/", limit=3)
+        assert len(page.files) == 3 and page.more is True

--- a/tests/test_storage/test_safety.py
+++ b/tests/test_storage/test_safety.py
@@ -1,0 +1,247 @@
+"""
+The security properties, each asserted so that it can fail.
+
+A test that cannot fail is not a test. For every refusal here there is a
+companion showing the same input is accepted once the protection is removed, so
+the assertion is measuring the guard rather than an accident of the fixture.
+"""
+
+from __future__ import annotations
+
+import time
+
+import pytest
+
+from sillo.storage.errors import SignatureInvalid, UnsafeKey
+from sillo.storage.paths import contain, normalise
+from sillo.storage.signing import SignedGrant, Signer
+from sillo.storage.sniff import sniff
+
+
+class TestKeys:
+    @pytest.mark.parametrize(
+        "key",
+        [
+            "../etc/passwd",
+            "a/../../etc/passwd",
+            "/etc/passwd",
+            "..",
+            "a/b/../../..",
+            "a\\b",
+            "a\x00b",
+            "a\nb",
+            "",
+            "   ",
+        ],
+    )
+    def test_an_unsafe_key_is_refused(self, key):
+        with pytest.raises(UnsafeKey):
+            normalise(key)
+
+    @pytest.mark.parametrize(
+        "key,expected",
+        [
+            ("a/b.txt", "a/b.txt"),
+            ("./a/b.txt", "a/b.txt"),
+            ("a//b.txt", "a/b.txt"),
+            ("a/./b.txt", "a/b.txt"),
+            ("a/c/../b.txt", "a/b.txt"),
+        ],
+    )
+    def test_a_safe_key_normalises(self, key, expected):
+        assert normalise(key) == expected
+
+    def test_two_spellings_of_one_name_are_one_key(self):
+        """Without NFC a macOS upload and a Linux upload of the same filename
+        are two objects that look identical in every listing."""
+        assert normalise("café.pdf") == normalise("café.pdf")
+
+    def test_a_key_that_is_too_long_is_refused(self):
+        with pytest.raises(UnsafeKey):
+            normalise("a" * 2000)
+
+    def test_a_segment_that_is_too_long_is_refused(self):
+        with pytest.raises(UnsafeKey):
+            normalise(f"a/{'b' * 300}/c.txt")
+
+    def test_containment_is_by_resolution(self, tmp_path):
+        """Not by looking for `..` in the input, which misses encodings,
+        symlinks, and whatever is invented next."""
+        outside = tmp_path / "outside"
+        outside.mkdir()
+        root = tmp_path / "bucket"
+        root.mkdir()
+
+        (root / "escape").symlink_to(outside)
+
+        with pytest.raises(UnsafeKey):
+            contain(root, "escape/secrets.txt")
+
+    def test_containment_permits_what_is_inside(self, tmp_path):
+        assert contain(tmp_path, "a/b.txt").is_relative_to(tmp_path.resolve())
+
+
+class TestSniffing:
+    def test_html_declared_as_an_image_is_stored_as_html(self):
+        """The shape of a stored cross-site scripting attempt: bytes that are
+        markup, a declared type that says otherwise."""
+        assert (
+            sniff(b"<!DOCTYPE html><script>alert(1)</script>", declared="image/png")
+            == "text/html"
+        )
+
+    def test_the_declared_type_cannot_promote_a_binary(self):
+        assert sniff(b"\x00\x01\x02\x03", declared="image/png") == "application/octet-stream"
+
+    def test_a_real_image_is_an_image(self):
+        assert sniff(b"\x89PNG\r\n\x1a\n" + b"\x00" * 32) == "image/png"
+
+    def test_svg_is_recognised_as_svg(self):
+        """It renders and it can carry script, so it must not become text."""
+        assert sniff(b'<svg xmlns="http://www.w3.org/2000/svg"/>') == "image/svg+xml"
+
+    def test_a_bare_script_tag_is_html(self):
+        assert sniff(b"<script>alert(1)</script>", declared="text/plain") == "text/html"
+
+    def test_an_unknown_binary_downloads_rather_than_renders(self):
+        assert sniff(b"\xde\xad\xbe\xef" * 20) == "application/octet-stream"
+
+    def test_an_empty_file_is_not_guessed_at(self):
+        assert sniff(b"") == "application/octet-stream"
+
+    def test_the_declared_type_only_breaks_ties_between_textual_types(self):
+        assert sniff(b"name,email\na,b", declared="text/csv") == "text/csv"
+        assert sniff(b"name,email\na,b", declared="text/html") == "text/plain"
+
+
+class TestSigning:
+    @pytest.fixture
+    def signer(self):
+        return Signer("a-secret-that-is-long-enough", "avatars")
+
+    def test_a_fresh_token_verifies(self, signer):
+        grant = SignedGrant("a.png", "GET", time.time() + 300)
+        assert signer.verify(signer.sign(grant), key="a.png", method="GET")
+
+    def test_an_expired_token_is_refused(self, signer):
+        token = signer.sign(SignedGrant("a.png", "GET", time.time() - 1))
+        with pytest.raises(SignatureInvalid):
+            signer.verify(token, key="a.png", method="GET")
+
+    def test_a_token_would_verify_if_it_had_not_expired(self, signer):
+        """Proving the previous test measures expiry and not something else."""
+        token = signer.sign(SignedGrant("a.png", "GET", time.time() + 300))
+        assert signer.verify(token, key="a.png", method="GET")
+
+    def test_a_tampered_token_is_refused(self, signer):
+        token = signer.sign(SignedGrant("a.png", "GET", time.time() + 300))
+        with pytest.raises(SignatureInvalid):
+            signer.verify(token[:-4] + "AAAA", key="a.png", method="GET")
+
+    def test_a_read_token_cannot_write(self, signer):
+        """A signature over the key alone is a URL that reads and overwrites."""
+        token = signer.sign(SignedGrant("a.png", "GET", time.time() + 300))
+        with pytest.raises(SignatureInvalid):
+            signer.verify(token, key="a.png", method="PUT")
+
+    def test_a_token_cannot_be_moved_to_another_object(self, signer):
+        token = signer.sign(SignedGrant("a.png", "GET", time.time() + 300))
+        with pytest.raises(SignatureInvalid):
+            signer.verify(token, key="b.png", method="GET")
+
+    def test_a_token_from_another_bucket_is_refused(self, signer):
+        """The namespace is mixed into the key material, so one secret does not
+        make every bucket's tokens interchangeable."""
+        other = Signer("a-secret-that-is-long-enough", "exports")
+        token = other.sign(SignedGrant("a.png", "GET", time.time() + 300))
+
+        with pytest.raises(SignatureInvalid):
+            signer.verify(token, key="a.png", method="GET")
+
+    def test_a_token_from_another_secret_is_refused(self, signer):
+        other = Signer("a-completely-different-secret", "avatars")
+        token = other.sign(SignedGrant("a.png", "GET", time.time() + 300))
+
+        with pytest.raises(SignatureInvalid):
+            signer.verify(token, key="a.png", method="GET")
+
+    def test_garbage_is_refused_rather_than_parsed(self, signer):
+        for rubbish in ("", ".", "x", "a.b", "not-a-token"):
+            with pytest.raises(SignatureInvalid):
+                signer.verify(rubbish, key="a.png", method="GET")
+
+    def test_every_refusal_says_the_same_thing(self, signer):
+        """Telling an unauthenticated caller which check failed tells them how
+        the signing works."""
+        messages = set()
+
+        for token in (
+            signer.sign(SignedGrant("a.png", "GET", time.time() - 1)),
+            signer.sign(SignedGrant("b.png", "GET", time.time() + 300)),
+            "rubbish.rubbish",
+        ):
+            try:
+                signer.verify(token, key="a.png", method="GET")
+            except SignatureInvalid as error:
+                messages.add(str(error))
+
+        assert len(messages) == 1
+
+    def test_the_grant_carries_its_limits(self, signer):
+        grant = SignedGrant("a.png", "PUT", time.time() + 300, "image/png", 1024)
+        verified = signer.verify(signer.sign(grant), key="a.png", method="PUT")
+
+        assert verified.content_type == "image/png"
+        assert verified.max_bytes == 1024
+
+    def test_a_short_secret_is_refused_at_construction(self):
+        """A signer built with nothing would mint forgeable tokens silently."""
+        with pytest.raises(ValueError, match="at least 16 bytes"):
+            Signer("short", "avatars")
+
+
+class TestForgedClaims:
+    """A payload that survives the MAC check is genuine; one that does not
+    should be refused rather than parsed. These cover the path where a token is
+    well-formed base64 and its claims are the wrong shape."""
+
+    def test_claims_of_the_wrong_type_are_refused(self):
+        import base64
+        import json
+
+        signer = Signer("a-secret-that-is-long-enough", "avatars")
+        payload = base64.urlsafe_b64encode(
+            json.dumps({"v": "v1", "k": "a.png", "m": "GET", "e": {}, "c": "", "s": 0}).encode()
+        ).decode().rstrip("=")
+
+        # Signed correctly, so it passes the MAC and reaches the parsing.
+        token = f"{payload}.{signer._mac(payload)}"
+
+        with pytest.raises(SignatureInvalid):
+            signer.verify(token, key="a.png", method="GET")
+
+    def test_a_claim_set_that_is_not_an_object_is_refused(self):
+        import base64
+        import json
+
+        signer = Signer("a-secret-that-is-long-enough", "avatars")
+        payload = base64.urlsafe_b64encode(json.dumps([1, 2, 3]).encode()).decode().rstrip("=")
+        token = f"{payload}.{signer._mac(payload)}"
+
+        with pytest.raises(SignatureInvalid):
+            signer.verify(token, key="a.png", method="GET")
+
+    def test_an_old_version_is_refused(self):
+        """So a token minted under one claim interpretation cannot be replayed
+        against a newer one."""
+        import base64
+        import json
+
+        signer = Signer("a-secret-that-is-long-enough", "avatars")
+        payload = base64.urlsafe_b64encode(
+            json.dumps({"v": "v0", "k": "a.png", "m": "GET", "e": 9e9}).encode()
+        ).decode().rstrip("=")
+        token = f"{payload}.{signer._mac(payload)}"
+
+        with pytest.raises(SignatureInvalid):
+            signer.verify(token, key="a.png", method="GET")


### PR DESCRIPTION
`sillo.storage` — one driver contract over local disk and S3-compatible object
storage, built against the five properties the Craftman storage panel specifies.

```python
storage = setup_storage(app, StorageConfig(
    default="attachments",
    buckets={
        "attachments": BucketConfig(driver="local", root="storage/attachments"),
        "avatars": BucketConfig(driver="local", root="storage/avatars",
                                policy=Owned(), accepts=("image/png",)),
    },
))

await storage.bucket("avatars").put(f"{user.id}/face.png", upload, user=user)
```

## The decisions worth reviewing

**`write` takes an async iterator and there is no bytes convenience.** The
moment one exists every caller reaches for it and "streamed uploads that never
buffer a whole file" becomes a comment rather than a property. Proven rather
than asserted: a test uploads 64 MB under `tracemalloc` and fails if peak
memory passes 8 MB.

**`page()` is the only way to list**, on every driver including memory. S3
pages at a thousand keys and local disk does not, so a contract returning a
plain list works in development and falls over the first time a bucket grows.
The memory driver pages too — a test double more permissive than production
hides the bug it exists to catch.

**Signed URLs cover method, expiry, content type and size.** Each one omitted
is a permission accidentally granted: a signature over the key alone is a URL
that reads *and* overwrites. Every refusal returns one identical message, with
a test asserting so — telling an unauthenticated caller which check failed
tells them how it works.

**Sniffing decides what is stored and served; the declaration is kept only to
be compared.** `FileInfo.mistyped` is a property, because a `.png` whose bytes
are HTML is the shape of stored XSS rather than a mistake. The serving route
pairs it with `nosniff`, a `Content-Disposition` and a sandbox CSP — sniffing
without those is half a defence.

**Policies are objects, not a visibility flag.** `Owned(prefix="{id}/")` is the
rule most applications actually want and two values cannot express, so every
project writes it by hand and forgets it in the second handler.

**A listener hook ships in v1.** Every other subsystem something wanted to
watch offered none, so the tooling wraps private methods on six classes — and
two of those seams turned out to be the wrong ones in ways nothing reported. A
storage operation is I/O measured in milliseconds; one attribute check per call
is free here in a way it is not on the request path.

## Testing

One contract suite, parametrised across drivers — "works locally, breaks on S3"
is the entire failure mode of a storage layer, and this is the only structure
that catches it. `DriverContract` is importable, so a third-party driver author
subclasses it with one fixture and finds out whether they are finished.

Every security property is asserted so that it *can* fail: for each refusal
there is a companion showing the same input is accepted once the guard is
removed.

```
150 storage tests · 4,820 core tests green · ruff + mypy clean
```

## Not in this branch

The S3 driver, console commands, and the vise panel. The extra is declared as
`storage-s3 = ["httpx"]` rather than boto3 — request signing is a few dozen
lines of HMAC and boto3 is a very large synchronous dependency to carry for it.
That driver should land only once it has run against MinIO in CI: "tested
against MinIO" and "tested against S3" are different claims and the README
should say which.