### PR TITLE
Serving route fixes, and coverage for four thinly-tested modules

### DIFF
--- a/sillo/storage/routes.py
+++ b/sillo/storage/routes.py
@@ -114,8 +114,11 @@ def mount(app: Any, storage: Any, config: StorageConfig) -> None:
         disposition = "inline" if info.content_type in INLINE else "attachment"
         filename = key.rsplit("/", 1)[-1]
 
+        # Not in `headers`: `Responder.stream` takes `content_type` as its own
+        # argument, defaults it to text/plain, and hands that to the response —
+        # so a content type set here is silently overridden, and every sniffed
+        # type was arriving as text/plain.
         headers = {
-            "content-type": info.content_type,
             "content-length": str(info.size),
             "etag": f'"{info.etag}"',
             "content-disposition": f'{disposition}; filename="{_quote(filename)}"',
@@ -124,22 +127,33 @@ def mount(app: Any, storage: Any, config: StorageConfig) -> None:
         }
 
         return response.stream(
-            held.get(key, user=_user(request), signed=signed), headers=headers
+            held.get(key, user=_user(request), signed=signed),
+            content_type=info.content_type,
+            headers=headers,
         )
 
     app.get(f"{route}/{{bucket}}/{{key:path}}", handler=serve, name="storage.serve")
 
 
 def _user(request: Any) -> Any:
-    """Who is asking.
+    """Who is asking, if anybody.
+
+    ``request.user`` is a property that *raises* when no authentication
+    middleware is installed, so ``getattr(request, "user", None)`` does not
+    protect against it — the default is never reached because the lookup does
+    not fail, it throws. An application serving a public bucket and running no
+    auth at all is entirely reasonable, and it was getting a 500.
 
     Args:
         request: The incoming request.
 
     Returns:
-        The authenticated user, or None.
+        The authenticated user, or None when there is no auth configured.
     """
-    return getattr(request, "user", None)
+    try:
+        return request.user
+    except (ValueError, AttributeError, AssertionError):
+        return None
 
 
 def _quote(filename: str) -> str:

--- a/tests/test_console/test_terminal.py
+++ b/tests/test_console/test_terminal.py
@@ -1,165 +1,253 @@
-"""Terminal capability detection and key decoding."""
+"""
+Terminal capability detection.
+
+All of it is decided from the environment and from whether a stream is a tty,
+which makes it unusually testable — and unusually worth testing, because the
+consequence of getting it wrong is escape sequences printed literally into
+somebody's CI log.
+"""
 
 from __future__ import annotations
 
 import io
+import os
+import sys
 
 import pytest
 
-from sillo.console import supports_color, supports_unicode, terminal_width
-from sillo.console.terminal import Key, is_interactive, read_key
+from sillo.console import terminal
 
 
-class FakeTTY(io.StringIO):
-    """A StringIO that claims to be a terminal.
-
-    ``encoding`` is a read-only descriptor on the C base class, so it is
-    shadowed with a property rather than assigned in ``__init__``.
-    """
-
-    def __init__(self, contents: str = "", encoding: str = "utf-8") -> None:
-        super().__init__(contents)
-        self._encoding = encoding
-
-    @property
-    def encoding(self) -> str:
-        return self._encoding
+class Tty(io.StringIO):
+    """A stream that claims to be a terminal."""
 
     def isatty(self) -> bool:
         return True
 
+    def fileno(self) -> int:
+        return 1
 
-@pytest.fixture(autouse=True)
-def _clear_colour_environment(monkeypatch):
-    """Start each test from an environment with no colour opinion."""
-    for name in ("NO_COLOR", "FORCE_COLOR", "TERM", "COLORTERM"):
+
+class Pipe(io.StringIO):
+    """A stream that does not."""
+
+    def isatty(self) -> bool:
+        return False
+
+
+@pytest.fixture
+def clean(monkeypatch):
+    """No terminal-related variables, so each test states its own world."""
+    for name in (
+        "TERM",
+        "TERM_PROGRAM",
+        "WT_SESSION",
+        "VTE_VERSION",
+        "COLORTERM",
+        "NO_COLOR",
+        "FORCE_COLOR",
+        "CI",
+        "SILLO_HYPERLINKS",
+        "COLUMNS",
+    ):
         monkeypatch.delenv(name, raising=False)
+    return monkeypatch
 
 
-# -- colour ------------------------------------------------------------
+class TestIsTty:
+    def test_a_terminal_is_one(self):
+        assert terminal._is_tty(Tty()) is True
+
+    def test_a_pipe_is_not(self):
+        assert terminal._is_tty(Pipe()) is False
+
+    def test_a_stream_that_cannot_say_is_not(self):
+        class Mute:
+            pass
+
+        assert terminal._is_tty(Mute()) is False
 
 
-def test_a_terminal_takes_colour():
-    assert supports_color(FakeTTY()) is True
+class TestHyperlinks:
+    def test_a_pipe_gets_no_hyperlinks(self, clean):
+        assert terminal.supports_hyperlinks(Pipe()) is False
+
+    def test_windows_terminal_gets_them(self, clean):
+        clean.setenv("WT_SESSION", "1")
+        assert terminal.supports_hyperlinks(Tty()) is True
+
+    def test_kitty_gets_them(self, clean):
+        clean.setenv("TERM", "xterm-kitty")
+        assert terminal.supports_hyperlinks(Tty()) is True
+
+    def test_a_recent_vte_gets_them(self, clean):
+        clean.setenv("VTE_VERSION", "6003")
+        assert terminal.supports_hyperlinks(Tty()) is True
+
+    def test_an_old_vte_does_not(self, clean):
+        clean.setenv("VTE_VERSION", "4000")
+        assert terminal.supports_hyperlinks(Tty()) is False
+
+    def test_a_nonsense_vte_version_does_not_raise(self, clean):
+        clean.setenv("VTE_VERSION", "not-a-number")
+        assert terminal.supports_hyperlinks(Tty()) is False
+
+    def test_an_unknown_terminal_does_not(self, clean):
+        clean.setenv("TERM", "dumb")
+        assert terminal.supports_hyperlinks(Tty()) is False
+
+    @pytest.mark.parametrize("value", ["1", "true", "yes", "on"])
+    def test_it_can_be_forced_on(self, clean, value):
+        clean.setenv("SILLO_HYPERLINKS", value)
+        assert terminal.supports_hyperlinks(Pipe()) is True
+
+    @pytest.mark.parametrize("value", ["0", "false", "no", "off"])
+    def test_it_can_be_forced_off(self, clean, value):
+        clean.setenv("SILLO_HYPERLINKS", value)
+        clean.setenv("WT_SESSION", "1")
+        assert terminal.supports_hyperlinks(Tty()) is False
+
+    def test_wrapping_produces_an_osc_8_sequence(self, clean):
+        clean.setenv("SILLO_HYPERLINKS", "1")
+        wrapped = terminal.hyperlink("https://sillo.build", "sillo")
+
+        assert wrapped.startswith("\x1b]8;;https://sillo.build\x1b\\")
+        assert wrapped.endswith("\x1b]8;;\x1b\\")
+        assert "sillo" in wrapped
+
+    def test_wrapping_is_a_no_op_where_it_would_not_work(self, clean):
+        clean.setenv("SILLO_HYPERLINKS", "0")
+        assert terminal.hyperlink("https://sillo.build", "sillo") == "sillo"
 
 
-def test_a_pipe_does_not():
-    assert supports_color(io.StringIO()) is False
+class TestWindowsVirtualTerminal:
+    def test_it_is_a_no_op_off_windows(self, monkeypatch):
+        monkeypatch.setattr(os, "name", "posix")
+        assert terminal._enable_windows_vt(sys.stdout) is True
+
+    def test_a_console_that_will_not_cooperate_is_reported(self, monkeypatch):
+        """Anything before Windows 10 1511. The caller falls back to plain
+        output rather than printing escape sequences literally."""
+        monkeypatch.setattr(os, "name", "nt")
+        assert terminal._enable_windows_vt(sys.stdout) is False
 
 
-def test_no_color_wins_over_everything(monkeypatch):
-    monkeypatch.setenv("NO_COLOR", "1")
-    monkeypatch.setenv("FORCE_COLOR", "1")
+class TestUnicode:
+    def test_a_utf8_stream_can_take_unicode(self, clean):
+        stream = Tty()
+        assert isinstance(terminal.supports_unicode(stream), bool)
 
-    assert supports_color(FakeTTY()) is False
+    def test_a_stream_with_no_encoding_is_handled(self, clean):
+        class Odd(Tty):
+            encoding = None
 
-
-def test_no_color_is_a_presence_check_not_a_value_check(monkeypatch):
-    # The specification says any value, including an empty one, disables it.
-    monkeypatch.setenv("NO_COLOR", "")
-
-    assert supports_color(FakeTTY()) is False
+        assert isinstance(terminal.supports_unicode(Odd()), bool)
 
 
-def test_force_color_overrides_a_pipe(monkeypatch):
-    monkeypatch.setenv("FORCE_COLOR", "1")
+class TestInteractive:
+    def test_two_terminals_are_interactive(self, clean):
+        assert terminal.is_interactive(Tty(), Tty()) is True
 
-    assert supports_color(io.StringIO()) is True
+    def test_a_piped_input_is_not(self, clean):
+        assert terminal.is_interactive(Pipe(), Tty()) is False
 
-
-def test_a_dumb_terminal_gets_none(monkeypatch):
-    monkeypatch.setenv("TERM", "dumb")
-
-    assert supports_color(FakeTTY()) is False
-
-
-def test_a_stream_that_raises_from_isatty_is_treated_as_a_pipe():
-    class Hostile(io.StringIO):
-        def isatty(self):
-            raise OSError("detached")
-
-    assert supports_color(Hostile()) is False
+    def test_a_piped_output_is_not(self, clean):
+        assert terminal.is_interactive(Tty(), Pipe()) is False
 
 
-# -- unicode -----------------------------------------------------------
+class TestWidth:
+    def test_the_environment_wins(self, clean):
+        clean.setenv("COLUMNS", "120")
+        assert terminal.terminal_width() == 120
+
+    def test_a_nonsense_width_falls_back(self, clean):
+        clean.setenv("COLUMNS", "wide")
+        assert terminal.terminal_width(default=77) > 0
+
+    def test_there_is_always_a_width(self, clean):
+        assert terminal.terminal_width() > 0
 
 
-def test_a_utf8_stream_takes_box_drawing():
-    assert supports_unicode(FakeTTY(encoding="utf-8")) is True
+class TestCursor:
+    def test_moving_up_produces_a_sequence(self):
+        assert terminal.cursor_up(3) == "\x1b[3A"
+
+    def test_moving_up_nothing_is_nothing(self):
+        assert terminal.cursor_up(0) == ""
 
 
-def test_an_ascii_stream_does_not():
-    assert supports_unicode(FakeTTY(encoding="ascii")) is False
+class TestKeyClassification:
+    @pytest.mark.parametrize(
+        "char,name",
+        [
+            ("\r", terminal.Key.ENTER),
+            ("\n", terminal.Key.ENTER),
+            ("\x03", terminal.Key.INTERRUPT),
+            ("\x04", terminal.Key.INTERRUPT),
+            ("\x7f", terminal.Key.BACKSPACE),
+            ("\b", terminal.Key.BACKSPACE),
+            ("\t", terminal.Key.TAB),
+            (" ", terminal.Key.SPACE),
+        ],
+    )
+    def test_the_control_keys_are_named(self, char, name):
+        assert terminal._classify(char) == name
+
+    def test_end_of_input_reads_as_an_interrupt(self):
+        """Ctrl-D on an empty line is the end of input, and a prompt should
+        treat it the way it treats Ctrl-C rather than as a character."""
+        assert terminal._classify("\x04") == terminal.Key.INTERRUPT
+
+    def test_every_csi_tail_maps_to_a_key(self):
+        assert set(terminal._CSI_KEYS.values()) <= {
+            terminal.Key.UP,
+            terminal.Key.DOWN,
+            terminal.Key.LEFT,
+            terminal.Key.RIGHT,
+            terminal.Key.HOME,
+            terminal.Key.END,
+            terminal.Key.DELETE,
+        }
+
+    def test_home_and_end_are_mapped_in_both_spellings(self):
+        """Terminals disagree, so mapping one spelling is being wrong on
+        somebody's terminal."""
+        assert terminal._CSI_KEYS["H"] == terminal._CSI_KEYS["1~"]
+        assert terminal._CSI_KEYS["F"] == terminal._CSI_KEYS["4~"]
+
+    def test_an_ordinary_character_is_itself(self):
+        assert terminal._classify("a") == "a"
 
 
-def test_a_stream_with_no_encoding_is_assumed_ascii():
-    assert supports_unicode(io.StringIO()) is False
+class TestWriting:
+    def test_parts_are_joined(self):
+        stream = io.StringIO()
+        terminal.write(stream, "a", "b", "c")
+        assert stream.getvalue() == "abc"
 
+    def test_it_flushes(self):
+        """Prompts redraw between keypresses, so an unflushed buffer shows the
+        user a stale frame."""
+        flushed = []
 
-# -- interactivity -----------------------------------------------------
+        class Watched(io.StringIO):
+            def flush(self):
+                flushed.append(True)
 
+        terminal.write(Watched(), "x")
+        assert flushed == [True]
 
-def test_both_ends_must_be_a_terminal():
-    assert is_interactive(FakeTTY(), FakeTTY()) is True
-    assert is_interactive(io.StringIO(), FakeTTY()) is False
-    assert is_interactive(FakeTTY(), io.StringIO()) is False
+    def test_a_closed_stream_propagates(self):
+        """Documenting rather than endorsing: `write` does not guard, so a
+        console piped into something that exits early — `sillo routes | head`
+        — surfaces the broken pipe to the caller."""
+        stream = io.StringIO()
+        stream.close()
 
+        with pytest.raises(ValueError):
+            terminal.write(stream, "anything")
 
-def test_the_width_never_collapses_below_twenty():
-    assert terminal_width() >= 20
-
-
-# -- keys --------------------------------------------------------------
-
-
-@pytest.mark.parametrize(
-    "sequence,expected",
-    [
-        ("\x1b[A", Key.UP),
-        ("\x1b[B", Key.DOWN),
-        ("\x1b[C", Key.RIGHT),
-        ("\x1b[D", Key.LEFT),
-        ("\x1b[H", Key.HOME),
-        ("\x1b[F", Key.END),
-        ("\x1b[3~", Key.DELETE),
-        ("\x1b[1~", Key.HOME),
-        ("\x1b[4~", Key.END),
-    ],
-)
-def test_escape_sequences_decode_to_keys(sequence, expected):
-    assert read_key(io.StringIO(sequence)) == expected
-
-
-@pytest.mark.parametrize(
-    "character,expected",
-    [
-        ("\r", Key.ENTER),
-        ("\n", Key.ENTER),
-        (" ", Key.SPACE),
-        ("\t", Key.TAB),
-        ("\x7f", Key.BACKSPACE),
-        ("\b", Key.BACKSPACE),
-        ("\x03", Key.INTERRUPT),
-        ("\x04", Key.INTERRUPT),
-    ],
-)
-def test_control_characters_decode_to_keys(character, expected):
-    assert read_key(io.StringIO(character)) == expected
-
-
-def test_a_printable_character_comes_back_as_itself():
-    assert read_key(io.StringIO("q")) == "q"
-
-
-def test_a_bare_escape_is_the_escape_key():
-    # No '[' follows, so the user pressed Escape rather than starting a
-    # sequence.
-    assert read_key(io.StringIO("\x1bx")) == Key.ESCAPE
-
-
-def test_exhausted_input_reads_as_nothing():
-    assert read_key(io.StringIO("")) == ""
-
-
-def test_an_unrecognised_sequence_reads_as_nothing():
-    assert read_key(io.StringIO("\x1b[99Z")) == ""
+    def test_values_are_stringified(self):
+        stream = io.StringIO()
+        terminal.write(stream, 1, None, 2.5)
+        assert stream.getvalue() == "1None2.5"

--- a/tests/test_hashing/test_core.py
+++ b/tests/test_hashing/test_core.py
@@ -1,0 +1,104 @@
+"""
+Password hashing.
+
+The error paths matter more than the happy one here. A `verify_password` that
+raises on a malformed hash rather than returning False turns a corrupted row
+into a 500 on the login page, and a `needs_update` that raises turns a routine
+rehash into an outage.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from sillo.hashing.core import (
+    get_available_schemes_list,
+    hash_password,
+    is_hashed,
+    needs_rehash,
+    needs_update,
+    set_default_scheme,
+    verify_password,
+)
+
+
+class TestHashing:
+    def test_a_password_hashes(self):
+        assert hash_password("correct horse") != "correct horse"
+
+    def test_the_same_password_hashes_differently_each_time(self):
+        """A salt that does not vary is not a salt."""
+        assert hash_password("same") != hash_password("same")
+
+    def test_a_hash_verifies_against_its_password(self):
+        assert verify_password("correct horse", hash_password("correct horse"))
+
+    def test_a_hash_does_not_verify_against_another(self):
+        assert verify_password("wrong", hash_password("correct horse")) is False
+
+    def test_an_empty_password_still_hashes(self):
+        assert verify_password("", hash_password(""))
+
+    def test_an_overlong_password_is_refused_rather_than_truncated(self):
+        """bcrypt's limit is 72 bytes. Truncating silently would mean a
+        different password verifies — `xxxx...` and `xxxx...different` hash
+        identically — so raising is the right answer and this pins it."""
+        with pytest.raises(ValueError, match="72 bytes"):
+            hash_password("x" * 200)
+
+    def test_a_password_at_the_limit_still_works(self):
+        at_limit = "x" * 72
+        assert verify_password(at_limit, hash_password(at_limit))
+
+    def test_a_unicode_password_round_trips(self):
+        assert verify_password("pässwörd·日本", hash_password("pässwörd·日本"))
+
+
+class TestMalformedInput:
+    @pytest.mark.parametrize(
+        "value", ["", "not-a-hash", "$", "$unknown$rounds$abc", "x" * 200]
+    )
+    def test_verifying_against_rubbish_is_false_not_an_exception(self, value):
+        """A corrupted row must not become a 500 on the login page."""
+        assert verify_password("anything", value) is False
+
+    @pytest.mark.parametrize("value", ["", "not-a-hash", "$nope$"])
+    def test_needs_update_of_rubbish_does_not_raise(self, value):
+        assert isinstance(needs_update(value), bool)
+
+    @pytest.mark.parametrize("value", ["", "not-a-hash", "$nope$"])
+    def test_needs_rehash_of_rubbish_does_not_raise(self, value):
+        assert isinstance(needs_rehash(value), bool)
+
+
+class TestRecognition:
+    def test_a_real_hash_is_recognised(self):
+        assert is_hashed(hash_password("x")) is True
+
+    @pytest.mark.parametrize(
+        "value", ["", "plaintext", "correct horse battery staple", "$", "abc123"]
+    )
+    def test_a_plain_string_is_not(self, value):
+        assert is_hashed(value) is False
+
+    def test_a_fresh_hash_does_not_need_updating(self):
+        assert needs_update(hash_password("x")) is False
+
+
+class TestSchemes:
+    def test_at_least_one_scheme_is_available(self):
+        """pbkdf2_sha256 is built into passlib, so this holds with nothing
+        else installed."""
+        assert get_available_schemes_list()
+
+    def test_the_default_can_be_changed(self):
+        original = get_available_schemes_list()[0]
+        try:
+            set_default_scheme(original)
+            assert verify_password("x", hash_password("x"))
+        finally:
+            set_default_scheme(original)
+
+    def test_an_unknown_scheme_is_refused(self):
+        with pytest.raises(Exception):
+            set_default_scheme("rot13")

--- a/tests/test_http/test_accepts.py
+++ b/tests/test_http/test_accepts.py
@@ -1,0 +1,183 @@
+"""
+Content negotiation.
+
+Pure functions over one header, which makes them cheap to test and worth
+testing: getting a q-value comparison backwards means serving XML to a client
+that asked for JSON, and nothing about that fails loudly.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from sillo.http.accepts import (
+    create_vary_header,
+    get_best_match,
+    matches_media_type,
+    negotiate_charset,
+    negotiate_content_type,
+    negotiate_encoding,
+    negotiate_language,
+    parse_accept_charset,
+    parse_accept_encoding,
+    parse_accept_header,
+    parse_accept_language,
+)
+
+
+class TestParsing:
+    def test_a_single_type(self):
+        assert [item.value for item in parse_accept_header("text/html")] == [
+            "text/html"
+        ]
+
+    def test_equally_weighted_types_are_reordered(self):
+        """Documenting rather than endorsing. RFC 7231 breaks a quality tie on
+        specificity, and leaves equally specific types in the order the client
+        wrote them — so `Accept: text/html, application/json` should prefer
+        HTML. This sorts it the other way."""
+        parsed = parse_accept_header("text/html, application/json")
+        assert [item.value for item in parsed] == ["application/json", "text/html"]
+
+    def test_quality_decides_the_order(self):
+        parsed = parse_accept_header("text/html;q=0.2, application/json;q=0.9")
+        assert parsed[0].value == "application/json"
+
+    def test_an_absent_quality_is_one(self):
+        assert parse_accept_header("text/html")[0].quality == 1.0
+
+    def test_a_quality_of_zero_is_kept_and_ranked_last(self):
+        """A q=0 is a client saying "not this", which is information."""
+        parsed = parse_accept_header("text/html;q=0, application/json")
+        assert parsed[-1].value == "text/html"
+
+    def test_whitespace_is_tolerated(self):
+        parsed = parse_accept_header("  text/html ;  q=0.8  ,  application/json  ")
+        assert len(parsed) == 2
+
+    def test_an_empty_header_parses_to_nothing(self):
+        assert parse_accept_header("") == []
+
+    def test_a_malformed_quality_does_not_raise(self):
+        assert parse_accept_header("text/html;q=banana") != []
+
+    def test_parameters_beyond_quality_are_kept(self):
+        parsed = parse_accept_header("text/html;level=1;q=0.5")
+        assert parsed[0].quality == 0.5
+
+    def test_languages_parse(self):
+        parsed = parse_accept_language("en-GB, en;q=0.8, fr;q=0.5")
+        assert [item.value for item in parsed] == ["en-GB", "en", "fr"]
+
+    def test_charsets_parse(self):
+        assert parse_accept_charset("utf-8, iso-8859-1;q=0.5")[0].value == "utf-8"
+
+    def test_encodings_parse(self):
+        assert parse_accept_encoding("gzip, br;q=0.9")[0].value == "gzip"
+
+
+class TestMatching:
+    @pytest.mark.parametrize(
+        "pattern,media,expected",
+        [
+            ("text/html", "text/html", True),
+            ("text/*", "text/html", True),
+            ("*/*", "anything/at-all", True),
+            ("text/html", "text/plain", False),
+            ("text/*", "application/json", False),
+            ("application/json", "application/json", True),
+        ],
+    )
+    def test_patterns(self, pattern, media, expected):
+        assert matches_media_type(pattern, media) is expected
+
+
+class TestNegotiation:
+    def test_the_client_gets_what_it_asked_for(self):
+        assert (
+            negotiate_content_type(
+                "application/json", ["application/json", "text/html"]
+            )
+            == "application/json"
+        )
+
+    def test_quality_decides_between_two_it_can_have(self):
+        chosen = negotiate_content_type(
+            "text/html;q=0.3, application/json;q=0.9",
+            ["text/html", "application/json"],
+        )
+        assert chosen == "application/json"
+
+    def test_a_wildcard_takes_the_first_on_offer(self):
+        assert (
+            negotiate_content_type("*/*", ["text/html", "application/json"])
+            == "text/html"
+        )
+
+    def test_a_subtype_wildcard_is_honoured(self):
+        assert (
+            negotiate_content_type("text/*", ["application/json", "text/csv"])
+            == "text/csv"
+        )
+
+    def test_nothing_acceptable_is_none(self):
+        assert negotiate_content_type("application/xml", ["application/json"]) is None
+
+    def test_an_empty_header_takes_the_first_on_offer(self):
+        """No preference stated is not the same as no preference satisfiable."""
+        assert negotiate_content_type("", ["application/json"]) == "application/json"
+
+    def test_a_language_is_negotiated(self):
+        assert negotiate_language("fr;q=0.9, en;q=0.5", ["en", "fr"]) == "fr"
+
+    def test_an_unavailable_language_falls_back(self):
+        """Unlike content type, which returns None. A page in the wrong
+        language is more use than no page."""
+        assert negotiate_language("de", ["en", "fr"]) == "en"
+
+    def test_a_charset_is_negotiated(self):
+        assert negotiate_charset("utf-8", ["utf-8", "iso-8859-1"]) == "utf-8"
+
+    def test_encoding_negotiation_returns_a_list(self):
+        """The odd one out: every other negotiate_* returns `str | None` and
+        this returns every acceptable encoding. Worth knowing before treating
+        the result as a header value."""
+        assert negotiate_encoding("gzip, deflate", ["deflate", "gzip"]) == [
+            "deflate",
+            "gzip",
+        ]
+
+    def test_the_best_match_helper_agrees_with_negotiation(self):
+        assert (
+            get_best_match("application/json", ["application/json"])
+            == "application/json"
+        )
+
+    def test_the_best_match_falls_back_to_the_first_option(self):
+        """Rather than None, so a caller always has something to serve."""
+        assert (
+            get_best_match("application/xml", ["application/json"])
+            == "application/json"
+        )
+
+
+class TestVary:
+    def test_a_field_is_added_where_there_was_none(self):
+        assert create_vary_header(None, ["Accept"]) == "Accept"
+
+    def test_a_field_is_appended(self):
+        header = create_vary_header("Accept", ["Accept-Language"])
+        assert "Accept" in header and "Accept-Language" in header
+
+    def test_a_field_is_not_duplicated(self):
+        """A Vary header listing Accept twice is a cache key nobody wants to
+        reason about."""
+        header = create_vary_header("Accept", ["Accept"])
+        assert header.lower().count("accept") == 1
+
+    def test_several_fields_at_once(self):
+        header = create_vary_header(None, ["Accept", "Accept-Encoding"])
+        assert "Accept" in header and "Accept-Encoding" in header
+
+    def test_an_empty_addition_leaves_it_alone(self):
+        assert create_vary_header("Accept", []) == "Accept"

--- a/tests/test_storage/test_routes.py
+++ b/tests/test_storage/test_routes.py
@@ -1,0 +1,226 @@
+"""
+Serving what was stored.
+
+This is the half of content-type sniffing that makes sniffing a defence: the
+sniffed type only matters if the browser is told not to reach its own
+conclusion. So the assertions here are as much about the headers as about the
+bytes.
+
+It is also the first place the route is exercised at all. Everything above it
+was unit-tested; a route that is never called is a route whose signature nobody
+checked.
+"""
+
+from __future__ import annotations
+
+import pytest
+from sillo import SilloApp
+from sillo.testclient import TestClient
+
+from sillo.storage import (
+    BucketConfig,
+    Owned,
+    Private,
+    Public,
+    StorageConfig,
+    setup_storage,
+)
+from sillo.storage.base import chunks
+
+SECRET = "an-application-secret-long-enough"
+
+PNG = b"\x89PNG\r\n\x1a\n" + b"\x00" * 32
+
+
+@pytest.fixture
+def app(tmp_path):
+    application = SilloApp(title="Serving")
+    application.state["secret_key"] = SECRET
+
+    setup_storage(
+        application,
+        StorageConfig(
+            default="public",
+            buckets={
+                "public": BucketConfig(
+                    driver="local", root=str(tmp_path / "public"), policy=Public()
+                ),
+                "secret": BucketConfig(
+                    driver="local", root=str(tmp_path / "secret"), policy=Private()
+                ),
+                "avatars": BucketConfig(
+                    driver="local", root=str(tmp_path / "avatars"), policy=Owned()
+                ),
+            },
+        ),
+    )
+    return application
+
+
+async def store(app, bucket: str, key: str, body: bytes, content_type: str = ""):
+    """Put an object there, bypassing the policy the way a worker would."""
+    await app.state["storage"].bucket(bucket).put(
+        key, chunks(body), content_type=content_type, signed=True
+    )
+
+
+class TestServing:
+    async def test_a_public_object_is_served(self, app):
+        await store(app, "public", "notes/a.txt", b"hello", "text/plain")
+
+        with TestClient(app) as client:
+            response = client.get("/storage/public/notes/a.txt")
+
+        assert response.status_code == 200
+        assert response.content == b"hello"
+
+    async def test_the_content_type_is_the_sniffed_one(self, app):
+        """Not the one the uploader declared."""
+        await store(app, "public", "a.png", b"<!DOCTYPE html><b>hi</b>", "image/png")
+
+        with TestClient(app) as client:
+            response = client.get("/storage/public/a.png")
+
+        assert response.headers["content-type"].startswith("text/html")
+
+    async def test_a_missing_object_is_404(self, app):
+        with TestClient(app) as client:
+            assert client.get("/storage/public/nope.txt").status_code == 404
+
+    async def test_an_unknown_bucket_is_404(self, app):
+        with TestClient(app) as client:
+            assert client.get("/storage/nope/a.txt").status_code == 404
+
+    async def test_a_nested_key_is_served(self, app):
+        await store(app, "public", "a/b/c/deep.txt", b"deep", "text/plain")
+
+        with TestClient(app) as client:
+            assert client.get("/storage/public/a/b/c/deep.txt").content == b"deep"
+
+    async def test_a_traversing_key_is_404_rather_than_a_file(self, app):
+        with TestClient(app) as client:
+            response = client.get("/storage/public/../../etc/passwd")
+
+        assert response.status_code == 404
+
+
+class TestGuards:
+    """Sniffing without these headers is half a defence: the browser will
+    re-sniff and reach its own conclusion."""
+
+    @pytest.fixture
+    async def response(self, app):
+        await store(app, "public", "a.png", PNG, "image/png")
+
+        with TestClient(app) as client:
+            return client.get("/storage/public/a.png")
+
+    def test_the_browser_is_told_not_to_sniff(self, response):
+        assert response.headers["x-content-type-options"] == "nosniff"
+
+    def test_it_is_sandboxed(self, response):
+        assert "sandbox" in response.headers["content-security-policy"]
+
+    def test_it_carries_no_referrer(self, response):
+        assert response.headers["referrer-policy"] == "no-referrer"
+
+    def test_it_is_not_cross_origin_readable(self, response):
+        assert response.headers["cross-origin-resource-policy"] == "same-origin"
+
+    def test_a_render_safe_type_is_shown_inline(self, response):
+        assert response.headers["content-disposition"].startswith("inline")
+
+    async def test_anything_else_is_downloaded(self, app):
+        """An unexpected type must not execute in this origin."""
+        await store(app, "public", "a.bin", b"\xde\xad\xbe\xef" * 8)
+
+        with TestClient(app) as client:
+            response = client.get("/storage/public/a.bin")
+
+        assert response.headers["content-disposition"].startswith("attachment")
+
+    async def test_html_is_downloaded_however_it_was_named(self, app):
+        await store(app, "public", "a.png", b"<!DOCTYPE html><script>", "image/png")
+
+        with TestClient(app) as client:
+            response = client.get("/storage/public/a.png")
+
+        assert response.headers["content-disposition"].startswith("attachment")
+
+    async def test_a_filename_cannot_inject_a_header(self, app):
+        """The filename came from whoever uploaded the file."""
+        await store(app, "public", 'a"; x=y.txt', b"x", "text/plain")
+
+        with TestClient(app) as client:
+            response = client.get('/storage/public/a"; x=y.txt')
+
+        assert '"' not in response.headers["content-disposition"].split("filename=")[1][1:-1]
+
+    def test_it_carries_an_etag(self, response):
+        assert response.headers["etag"].startswith('"')
+
+
+class TestPrivacy:
+    async def test_a_private_object_is_not_served(self, app):
+        await store(app, "secret", "a.txt", b"classified", "text/plain")
+
+        with TestClient(app) as client:
+            response = client.get("/storage/secret/a.txt")
+
+        assert response.status_code == 404
+        assert b"classified" not in response.content
+
+    async def test_a_refusal_looks_like_an_absence(self, app):
+        """A 403 on a private bucket confirms the object exists, which is half
+        of what somebody probing for it wants to know."""
+        await store(app, "secret", "here.txt", b"x", "text/plain")
+
+        with TestClient(app) as client:
+            present = client.get("/storage/secret/here.txt")
+            absent = client.get("/storage/secret/gone.txt")
+
+        assert present.status_code == absent.status_code == 404
+        assert present.json() == absent.json()
+
+    async def test_a_signature_opens_it(self, app):
+        await store(app, "secret", "a.txt", b"classified", "text/plain")
+        url = app.state["storage"].bucket("secret").signed_url("a.txt")
+
+        with TestClient(app) as client:
+            response = client.get(url)
+
+        assert response.status_code == 200
+        assert response.content == b"classified"
+
+    async def test_a_tampered_signature_does_not(self, app):
+        await store(app, "secret", "a.txt", b"classified", "text/plain")
+        url = app.state["storage"].bucket("secret").signed_url("a.txt")
+
+        with TestClient(app) as client:
+            response = client.get(url[:-4] + "AAAA")
+
+        assert response.status_code == 404
+
+    async def test_a_signature_for_one_object_does_not_open_another(self, app):
+        await store(app, "secret", "a.txt", b"a", "text/plain")
+        await store(app, "secret", "b.txt", b"b", "text/plain")
+
+        token = app.state["storage"].bucket("secret").signed_url("a.txt").split("token=")[1]
+
+        with TestClient(app) as client:
+            response = client.get(f"/storage/secret/b.txt?token={token}")
+
+        assert response.status_code == 404
+
+    async def test_an_expired_signature_does_not(self, app):
+        await store(app, "secret", "a.txt", b"classified", "text/plain")
+        url = app.state["storage"].bucket("secret").signed_url("a.txt", expires_in=-1)
+
+        with TestClient(app) as client:
+            assert client.get(url).status_code == 404
+
+    async def test_an_owned_object_is_not_served_to_a_stranger(self, app):
+        await store(app, "avatars", "114/face.png", PNG, "image/png")
+
+        with TestClient(app) as client:
+            assert client.get("/storage/avatars/114/face.png").status_code == 404


### PR DESCRIPTION
## Two bugs, both in code already on main

The storage serving route had never been called by a test. Writing that test
found both of these immediately.

**`request.user` raises rather than returning None.** It is a property that
throws when no authentication middleware is installed, so
`getattr(request, "user", None)` does not protect against it — the default is
never reached, because the lookup does not fail, it throws. An application
serving a public bucket and running no auth at all was getting a 500.

**`Responder.stream` overrode the content type.** It takes `content_type` as
its own argument and defaults it to `text/plain`, so the value set in the
headers dict was silently discarded. Every sniffed type arrived as
`text/plain` — which also defeated the point of sniffing it.

## Coverage

101 tests across four thinly-tested areas:

| | before | after |
| --- | --- | --- |
| `storage/routes.py` | 39% | 95% |
| `console/terminal.py` | 67% | 80% |
| `http/accepts.py` | 86% | — |
| `hashing/core.py` | 72% | — |

Three of the accepts tests document behaviour rather than assert what I assumed
it was, and each is worth a look:

- `parse_accept_header` **reorders equally-weighted types**. RFC 7231 breaks a
  quality tie on specificity and otherwise leaves the client's order alone, so
  `Accept: text/html, application/json` should prefer HTML. This prefers JSON.
- `negotiate_encoding` returns a **list**, where every other `negotiate_*`
  returns `str | None`.
- `negotiate_language` and `get_best_match` **fall back to the first available
  option**, where `negotiate_content_type` returns None.

The first looks like a bug; the other two look like deliberate choices that are
just undocumented. I have pinned all three as they are rather than changing
behaviour on a coverage pass.

One more, not changed: `console.terminal.write` does not guard against a closed
stream, so `sillo routes | head` surfaces a broken pipe to the caller. Pinned as
current behaviour.