### PR TITLE
A shared instance registry: current_storage(), current_mail(), no request required

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `sillo.storage.current_storage()` and `sillo.storage.bucket(name)` — reach the `Storage` `setup_storage` registered, from a handler, a queue job, or a script, without the application object or a request.
+- `sillo.mail.current_mail()` and `sillo.mail.send_email(...)` — same shape, for the `MailClient` `setup_mail` registered.
+- `sillo._internals.registry.InstanceRegistry`, the shared internal mechanism behind both: a plain slot filled once at startup and read from anywhere, raising `NotConfiguredError` — not `None` — when asked before `setup_x` has run. Documented in [Instance Registry](https://sillo.build/advanced/context-binding/).
+
 ## [0.2.0] - 2026-08-18
 
 A minor release, not a patch: `sillo.env` is new public API, and `.env` now

--- a/docs/docs/astro.config.mjs
+++ b/docs/docs/astro.config.mjs
@@ -296,6 +296,7 @@ export default defineConfig({
                         { label: 'Application Lifecycle', link: '/advanced/application-lifecycle/' },
                         { label: 'Configuration System', link: '/advanced/configuration/' },
                         { label: 'Type System & Encoding', link: '/advanced/types-and-encoding/' },
+                        { label: 'Instance Registry', link: '/advanced/context-binding/' },
                     ],
                 },
                 {

--- a/docs/docs/src/content/docs/advanced/context-binding.md
+++ b/docs/docs/src/content/docs/advanced/context-binding.md
@@ -1,0 +1,152 @@
+---
+title: "Instance Registry"
+description: "The shared mechanism behind current_storage(), current_mail(), and every setup_x() that follows — a plain slot filled at startup, reachable from anywhere"
+---
+
+> Internal engineering reference for a small piece of infrastructure shared
+> across subsystems.
+>
+> Source: `core/sillo/_internals/registry.py` (~90 lines)
+
+---
+
+## 1. The problem
+
+Every `setup_x(app, config)` in the framework follows the same shape: build
+one long-lived instance, put it on `app.state`, register lifecycle hooks,
+return it. `setup_record`, `setup_work`, `setup_mail`, `setup_storage` all do
+exactly this.
+
+Getting the instance back is where they used to diverge. A handler could hold
+a closure over it, or reach through `request.base_app.state["storage"]` — both
+fine when there is a request in hand and the code holding it does not mind an
+import shaped by that. Neither works well for the routes module that wants to
+call `bucket(...)` without importing the application that built it (a
+circular import, since the application is what registers the routes), and
+neither works *at all* for a queue job or a script, where there is no request
+and often no `app` object lying around either.
+
+The keys were also picked independently per subsystem —
+`app.state["storage"]`, `app.state["mail_client"]`, `app.state["record"]` —
+untyped strings a typo in either the write or the read silently breaks.
+
+## 2. What this is, and what it deliberately is not
+
+`InstanceRegistry` is a plain slot: `register(instance)` fills it,
+`current(...)` reads it back, and asking before anything was registered raises
+a `NotConfiguredError` naming the `setup_x` call that was skipped, rather than
+returning `None` for code to accept as if it were valid.
+
+```python
+class InstanceRegistry(Generic[T]):
+    def __init__(self, label: str) -> None:
+        self._label = label
+        self._instance: T | None = None
+
+    def register(self, instance: T) -> None:
+        self._instance = instance
+
+    def current(self, *, setup: str, example: str) -> T:
+        if self._instance is None:
+            raise NotConfiguredError(...)
+        return self._instance
+```
+
+That is the whole mechanism. Two things it is not, on purpose:
+
+**Not a `ContextVar`.** An earlier version of this bound the instance per
+request, with a small ASGI middleware setting and resetting a
+`contextvars.ContextVar` around each call — the same trick
+[`sillo_inertia`](https://github.com/sillohq/inertia) uses for
+`current_inertia()`, where it is the right answer: an Inertia response *is* a
+function of the request answering it, and there is no such thing as rendering
+one outside of one. Mail and storage are different — a queue job sending a
+receipt or a script backfilling a bucket has no request to bind from, and
+those are not edge cases for either subsystem, they are close to half its
+traffic. Tying the lookup to the request lifecycle would have solved the
+import problem and reintroduced the exact "how do I reach this from a
+background job" problem the design was meant to remove. Registering once, at
+startup, removes the request from the question entirely.
+
+**Not per-application.** The registry holds one instance at a time, whichever
+`setup_x` call registered most recently — there is no key, no lookup by
+`app`. This is the same assumption `app.state["storage"]` already made *for
+that application* (one `Storage` per app), made explicit at process scope
+instead: one registered `Storage` at a time, full stop. A process serving two
+applications with two different storage configurations — most often a test
+suite building app after app — gets whichever was set up last, and that is a
+deliberate trade for never needing an application object to do the lookup,
+not an oversight. It has not needed to be anything more: sillo applications
+are one per process in every deployment shape the framework targets.
+
+## 3. Who uses it
+
+| Subsystem | Registry label | Reader |
+|---|---|---|
+| `sillo.storage` | `"storage"` | `current_storage()`, `bucket(name)` |
+| `sillo.mail` | `"mail client"` | `current_mail()`, `send_email(...)` |
+
+Each subsystem owns one `InstanceRegistry[T]` at module scope in its own
+`context.py`, and calls `register(instance)` from its `setup_x` function —
+that is the entire integration cost. `app.state["storage"]` and
+`app.state["mail_client"]` are untouched; this is an addition, not a
+replacement, for code that already holds the application object and would
+rather use it.
+
+```python
+# sillo/storage/context.py
+_registry: InstanceRegistry[Storage] = InstanceRegistry("storage")
+
+def register(storage: Storage) -> None:
+    _registry.register(storage)
+
+def current_storage() -> Storage:
+    return _registry.current(setup="setup_storage", example=_EXAMPLE)
+```
+
+```python
+# sillo/storage/storage.py — inside setup_storage
+storage = Storage(config, secret=secret or _app_secret(app))
+app.state["storage"] = storage
+app.on_shutdown(storage.close)
+register(storage)          # ← the one line each setup_x adds
+```
+
+## 4. The failure mode this was built to avoid
+
+A cache miss that returns `None` — instead of a sentinel distinct from every
+valid cached value — invites code to accept `None` as data. The same shape
+would happen here if `current_storage()` returned `None` before startup: a
+handler that forgot to call `setup_storage` would get an `AttributeError` on
+whatever it tried to do with `None`, three call frames away from the actual
+mistake and looking nothing like it.
+
+`NotConfiguredError` is raised at the point of the mistake, and names the
+`setup_x` call that should have run first:
+
+```
+No storage has been set up yet.
+
+This reads the storage setup_storage registers. Call it during startup,
+before anything asks for the storage back:
+
+    storage = setup_storage(app, StorageConfig(default="attachments", buckets={...}))
+
+If it already runs somewhere, check that this code path executes after it —
+module import order, not request order, decides whether that has happened.
+```
+
+The last line is the one worth reading twice: because registration happens at
+`setup_x` time and not on first request, the failure this actually catches in
+practice is an import-order bug — a module reading `current_storage()` at its
+own import time, before the application module that calls `setup_storage` has
+run.
+
+## 5. Testing
+
+`tests/test_internals/test_registry.py` covers the primitive alone — no app,
+no request, nothing async unless the test itself needs to be — proving
+`register`/`current` work as a plain function call would. `tests/test_storage/test_context.py`
+and `tests/test_mail/test_context.py` cover the wiring: that `setup_storage`
+and `setup_mail` actually call `register`, that the last call in a process
+wins, and that a `NotConfiguredError` names the right subsystem.

--- a/docs/docs/src/content/docs/advanced/mail.md
+++ b/docs/docs/src/content/docs/advanced/mail.md
@@ -621,16 +621,12 @@ def get_mail_client(request) -> MailClient:
 Accesses the client stored in `app.state.mail_client` via the request's state
 proxy. Requires a request — `current_mail()` below does not.
 
-### `current_mail()` and `send_email(...)`
+### `send_email(...)`
 
-**File:** `core/sillo/mail/context.py`, `core/sillo/mail/client.py`
+**File:** `core/sillo/mail/client.py`
 
-`setup_mail` also registers the client with `sillo._internals.registry`, the
-same [instance registry](/advanced/context-binding/) `sillo.storage` uses.
-`current_mail()` reads it back; `send_email(...)` is `current_mail().send_email(...)`
-written out. Neither takes a request, because neither is scoped to one — mail
-is sent from queue jobs and scripts at least as often as from a handler, and
-this needed to work in all three the same way:
+The way to send mail from a handler, a queue job, or a script — nothing to
+fetch first, no request required:
 
 ```python
 from sillo.mail import send_email
@@ -639,8 +635,22 @@ async def process_signup(user):  # a queue job, not a handler
     await send_email(user.email, "Welcome", body="...")
 ```
 
-The trade this makes explicit: the registry holds one client at a time,
-whichever `setup_mail` call registered last. That is exactly the assumption
+### `current_mail()`
+
+**File:** `core/sillo/mail/context.py`
+
+The client itself, for the two things `send_email(...)` doesn't cover:
+`send_message(message)` for a prebuilt `EmailMessage`, and
+`send_template_email(...)` when its distinct signature reads better than
+`send_email`'s `template_name=`/`template_context=` kwargs. Most code never
+needs this — `send_email(...)` already is `current_mail().send_email(...)`.
+
+`setup_mail` registers the client with `sillo._internals.registry`, the same
+[instance registry](/advanced/context-binding/) `sillo.storage` uses — a
+plain slot filled at startup, not scoped to a request, because mail is sent
+from queue jobs and scripts at least as often as from a handler. The trade
+that makes explicit: the registry holds one client at a time, whichever
+`setup_mail` call registered last. That is exactly the assumption
 `app.state.mail_client` already made — one mail client per application — made
 visible rather than implicit in a lookup key.
 

--- a/docs/docs/src/content/docs/advanced/mail.md
+++ b/docs/docs/src/content/docs/advanced/mail.md
@@ -619,21 +619,43 @@ def get_mail_client(request) -> MailClient:
 ```
 
 Accesses the client stored in `app.state.mail_client` via the request's state
-proxy.
+proxy. Requires a request — `current_mail()` below does not.
+
+### `current_mail()` and `send_email(...)`
+
+**File:** `core/sillo/mail/context.py`, `core/sillo/mail/client.py`
+
+`setup_mail` also registers the client with `sillo._internals.registry`, the
+same [instance registry](/advanced/context-binding/) `sillo.storage` uses.
+`current_mail()` reads it back; `send_email(...)` is `current_mail().send_email(...)`
+written out. Neither takes a request, because neither is scoped to one — mail
+is sent from queue jobs and scripts at least as often as from a handler, and
+this needed to work in all three the same way:
+
+```python
+from sillo.mail import send_email
+
+async def process_signup(user):  # a queue job, not a handler
+    await send_email(user.email, "Welcome", body="...")
+```
+
+The trade this makes explicit: the registry holds one client at a time,
+whichever `setup_mail` call registered last. That is exactly the assumption
+`app.state.mail_client` already made — one mail client per application — made
+visible rather than implicit in a lookup key.
 
 ### Usage Pattern
 
 ```python
-from sillo.mail import setup_mail, get_mail_client, MailConfig
+from sillo.mail import setup_mail, send_email, MailConfig
 
 # At startup
 config = MailConfig.for_gmail("user@gmail.com", "app-password")
 setup_mail(app, config)
 
-# In handler
-async def send_welcome(request, response):
-    client = get_mail_client(request)
-    result = await client.send_template_email(
+# In handler, a queue job, or a script
+async def send_welcome(user):
+    result = await send_email(
         to="newuser@example.com",
         subject="Welcome!",
         template_name="welcome",

--- a/docs/docs/src/content/docs/advanced/storage.md
+++ b/docs/docs/src/content/docs/advanced/storage.md
@@ -61,13 +61,17 @@ Nothing below `Bucket` knows about users, policies or content types.
 
 ### Reaching it from anywhere
 
-`setup_storage` puts `Storage` on `app.state["storage"]`, and also registers
-it with `sillo._internals.registry` — a plain slot filled once at startup, not
-scoped to a request. `sillo.storage.current_storage()` and
-`sillo.storage.bucket(name)` read it back, and work identically in a route
-handler, a queue job, or a script, because none of those are treated
-differently. See [Instance Registry](/advanced/context-binding/) for the
-mechanism and the trade it makes — one registered `Storage` at a time.
+`sillo.storage.bucket(name)` works in a route handler, a queue job, or a
+script — nothing to fetch first, no request required. `current_storage()` is
+the `Storage` itself, for the handful of things `bucket()` doesn't cover
+(`.listen()`, building a bucket at runtime); most code never needs it.
+
+Both are registered by `setup_storage`, alongside the existing
+`app.state["storage"]`, with `sillo._internals.registry` — a plain slot filled
+once at startup, not scoped to a request, because storage is written to from
+queue jobs and scripts at least as often as from a handler. See
+[Instance Registry](/advanced/context-binding/) for the mechanism and the
+trade it makes — one registered `Storage` at a time.
 
 ---
 

--- a/docs/docs/src/content/docs/advanced/storage.md
+++ b/docs/docs/src/content/docs/advanced/storage.md
@@ -34,6 +34,7 @@ sillo/storage/
 ├── paths.py         Key normalisation and containment
 ├── routes.py        The serving route
 ├── errors.py        Five exceptions
+├── context.py       current_storage() — reaches the registered Storage
 └── drivers/
     ├── memory.py    Dictionary. The contract's definition, and the test double.
     └── local.py     Files, written atomically, contained by resolution.
@@ -57,6 +58,16 @@ graph TD
 ```
 
 Nothing below `Bucket` knows about users, policies or content types.
+
+### Reaching it from anywhere
+
+`setup_storage` puts `Storage` on `app.state["storage"]`, and also registers
+it with `sillo._internals.registry` — a plain slot filled once at startup, not
+scoped to a request. `sillo.storage.current_storage()` and
+`sillo.storage.bucket(name)` read it back, and work identically in a route
+handler, a queue job, or a script, because none of those are treated
+differently. See [Instance Registry](/advanced/context-binding/) for the
+mechanism and the trade it makes — one registered `Storage` at a time.
 
 ---
 

--- a/docs/docs/src/content/docs/guides/storage.mdx
+++ b/docs/docs/src/content/docs/guides/storage.mdx
@@ -52,19 +52,19 @@ async def upload_avatar(request, response):
     return response.json({"key": stored.key, "size": stored.size})
 ```
 
-`bucket(name)` is shorthand for `current_storage().bucket(name)`: it reaches
-for the `Storage` `setup_storage` registered at startup, without needing the
-application object or a request in hand. That makes it work identically in a
-route handler, a queue job, or a script — see
-[Instance Registry](/advanced/context-binding/) for why it is not tied to the
-request. Holding the instance `setup_storage` returned works everywhere too,
-and is what a module doing nothing else with storage should probably do
-instead of importing `bucket` for one call:
+`bucket(name)` just works — in this handler, in a queue job, in a script —
+with nothing to set up beyond calling `setup_storage` once at startup. There
+is no object to fetch first and no request to have in hand; import it and
+call it. (If you're curious how, that's in
+[Instance Registry](/advanced/context-binding/) — nothing here depends on
+knowing.)
+
+The only reason to hold onto what `setup_storage` returns is for the handful
+of things `bucket()` doesn't cover — `.listen()` below, or building a second
+bucket at runtime:
 
 ```python
 storage = setup_storage(app, StorageConfig(...))
-...
-await storage.bucket("avatars").put(...)
 ```
 
 ## What ships

--- a/docs/docs/src/content/docs/guides/storage.mdx
+++ b/docs/docs/src/content/docs/guides/storage.mdx
@@ -37,13 +37,12 @@ storage = setup_storage(app, StorageConfig(
 Then, in a handler:
 
 ```python
-from sillo.storage import stream_upload
+from sillo.storage import bucket, stream_upload
 
 async def upload_avatar(request, response):
     upload = (await request.files)["avatar"]
-    bucket = request.base_app.state["storage"].bucket("avatars")
 
-    stored = await bucket.put(
+    stored = await bucket("avatars").put(
         f"{request.user.identity}/face.png",
         stream_upload(upload),
         content_type=upload.content_type or "",
@@ -51,6 +50,21 @@ async def upload_avatar(request, response):
     )
 
     return response.json({"key": stored.key, "size": stored.size})
+```
+
+`bucket(name)` is shorthand for `current_storage().bucket(name)`: it reaches
+for the `Storage` `setup_storage` registered at startup, without needing the
+application object or a request in hand. That makes it work identically in a
+route handler, a queue job, or a script — see
+[Instance Registry](/advanced/context-binding/) for why it is not tied to the
+request. Holding the instance `setup_storage` returned works everywhere too,
+and is what a module doing nothing else with storage should probably do
+instead of importing `bucket` for one call:
+
+```python
+storage = setup_storage(app, StorageConfig(...))
+...
+await storage.bucket("avatars").put(...)
 ```
 
 ## What ships

--- a/sillo/_internals/registry.py
+++ b/sillo/_internals/registry.py
@@ -1,0 +1,101 @@
+"""
+sillo._internals.registry — the instance a setup function just built, reachable
+from anywhere.
+
+Several subsystems work the same way: ``setup_x(app, config)`` builds one
+long-lived instance and puts it on ``app.state``, and code deep inside a
+handler, a background job, or a script wants it back. Reaching through
+``request.base_app.state["x"]`` only works when there is a request in hand,
+needs it threaded down to wherever the lookup happens, and is untyped and
+keyed by a string every subsystem picks independently (``"storage"``,
+``"mail_client"``, ``"record"``, ...).
+
+This is deliberately not request-scoped and has nothing to do with the request
+lifecycle: ``setup_x`` registers the instance once, at startup, and it stays
+registered for the life of the process — reachable from a request handler, a
+queue worker, a scheduled job, or a script that just imported the module,
+identically. The framework's own assumption throughout — one instance per
+subsystem per application — is what makes "the one most recently registered"
+the right answer everywhere it is asked.
+
+Asking before anything registered is a loud :class:`NotConfiguredError`,
+naming the setup call that was skipped, rather than ``None`` accepted as if it
+were a valid value.
+"""
+
+from __future__ import annotations
+
+from typing import Generic, TypeVar
+
+__all__ = ["InstanceRegistry", "NotConfiguredError"]
+
+T = TypeVar("T")
+
+
+class NotConfiguredError(RuntimeError):
+    """Raised when a registered instance is asked for before it exists."""
+
+
+_NOT_CONFIGURED = """No {what} has been set up yet.
+
+This reads the {what} {setup} registers. Call it during startup, before
+anything asks for the {what} back:
+
+    {example}
+
+If it already runs somewhere, check that this code path executes after it —
+module import order, not request order, decides whether that has happened.
+"""
+
+
+class InstanceRegistry(Generic[T]):
+    """Holds the most recently registered instance of one subsystem.
+
+    A subsystem builds one of these at module scope, registers from its own
+    ``setup_x`` function, and reads it back from a small module-level function
+    such as ``current_storage()``. There is no per-request or per-task
+    scoping — this is a plain slot, filled once at startup and read from
+    wherever, exactly like the module-level singletons it replaces.
+
+    Args:
+        label: A short name for what this holds, used only in error messages
+            (e.g. ``"storage"``).
+    """
+
+    __slots__ = ("_instance", "_label")
+
+    def __init__(self, label: str) -> None:
+        """Build an empty registry.
+
+        Args:
+            label: A short name for what this holds.
+        """
+        self._label = label
+        self._instance: T | None = None
+
+    def register(self, instance: T) -> None:
+        """Record *instance* as the one to hand back from now on.
+
+        Args:
+            instance: What ``setup_x`` built.
+        """
+        self._instance = instance
+
+    def current(self, *, setup: str, example: str) -> T:
+        """The registered instance.
+
+        Args:
+            setup: The setup function's name, e.g. ``"setup_storage"``.
+            example: One line showing that function called.
+
+        Returns:
+            The registered instance.
+
+        Raises:
+            NotConfiguredError: If nothing has been registered yet.
+        """
+        if self._instance is None:
+            raise NotConfiguredError(
+                _NOT_CONFIGURED.format(what=self._label, setup=setup, example=example)
+            )
+        return self._instance

--- a/sillo/mail/__init__.py
+++ b/sillo/mail/__init__.py
@@ -1,5 +1,6 @@
-from .client import MailClient, get_mail_client, setup_mail
+from .client import MailClient, get_mail_client, send_email, setup_mail
 from .config import MailConfig
+from .context import NotConfiguredError, current_mail
 from .models import EmailAttachment, EmailMessage, EmailResult
 
 __all__ = [
@@ -8,6 +9,9 @@ __all__ = [
     "EmailResult",
     "MailClient",
     "MailConfig",
+    "NotConfiguredError",
+    "current_mail",
     "get_mail_client",
+    "send_email",
     "setup_mail",
 ]

--- a/sillo/mail/client.py
+++ b/sillo/mail/client.py
@@ -7,6 +7,7 @@ from pathlib import Path
 from typing import Any
 
 from .config import MailConfig
+from .context import current_mail, register
 from .models import EmailMessage, EmailResult
 
 logger = logging.getLogger("sillo.mail")
@@ -246,6 +247,7 @@ def setup_mail(app, config: MailConfig | None = None) -> MailClient:
     app.state["mail_client"] = client
     app.on_startup(client.start)
     app.on_shutdown(client.stop)
+    register(client)
     return client
 
 
@@ -257,3 +259,38 @@ def get_mail_client(request) -> MailClient:
             "Mail client not initialized. Call setup_mail(app) during startup."
         )
     return client
+
+
+async def send_email(
+    to: str | list[str],
+    subject: str,
+    body: str | None = None,
+    **kwargs: Any,
+) -> EmailResult:
+    """Send an email through the client :func:`setup_mail` registered.
+
+    Shorthand for ``current_mail().send_email(...)``, for code that has no
+    reason to hold the whole :class:`MailClient` — a route handler, a queue
+    job, a script, anywhere after startup::
+
+        from sillo.mail import send_email
+
+        @app.post("/signup")
+        async def signup(request, response):
+            ...
+            await send_email(user.email, "Welcome", body="...")
+
+    Args:
+        to: One address or several.
+        subject: The subject line.
+        body: The plain-text body. See :meth:`MailClient.send_email` for the
+            rest — templates, attachments, HTML — all accepted here too.
+        **kwargs: Forwarded to :meth:`MailClient.send_email`.
+
+    Returns:
+        The result.
+
+    Raises:
+        NotConfiguredError: If ``setup_mail`` has not run yet.
+    """
+    return await current_mail().send_email(to, subject, body, **kwargs)

--- a/sillo/mail/context.py
+++ b/sillo/mail/context.py
@@ -1,0 +1,49 @@
+"""
+sillo.mail.context — the mail client :func:`~sillo.mail.client.setup_mail`
+built, reachable from anywhere.
+
+The same shape as :mod:`sillo.storage.context`, sharing the same
+:class:`~sillo._internals.registry.InstanceRegistry`. See that module's
+docstring for why this exists rather than a lookup through ``app.state``, and
+why it has nothing to do with the request lifecycle — mail is sent from queue
+jobs and scripts at least as often as from a request handler.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from .._internals.registry import InstanceRegistry, NotConfiguredError
+
+if TYPE_CHECKING:
+    from .client import MailClient
+
+__all__ = ["NotConfiguredError", "current_mail", "register"]
+
+_registry: InstanceRegistry[MailClient] = InstanceRegistry("mail client")
+
+_EXAMPLE = "mail = setup_mail(app, MailConfig(smtp_host=...))"
+
+
+def register(client: MailClient) -> None:
+    """Record *client* as the one to hand back from now on.
+
+    Called by :func:`~sillo.mail.client.setup_mail`; there is no reason to
+    call this directly outside a test of the registry itself.
+
+    Args:
+        client: What ``setup_mail`` built.
+    """
+    _registry.register(client)
+
+
+def current_mail() -> MailClient:
+    """The mail client ``setup_mail`` registered.
+
+    Returns:
+        The registered :class:`~sillo.mail.client.MailClient`.
+
+    Raises:
+        NotConfiguredError: If ``setup_mail`` has not run yet.
+    """
+    return _registry.current(setup="setup_mail", example=_EXAMPLE)

--- a/sillo/storage/__init__.py
+++ b/sillo/storage/__init__.py
@@ -37,6 +37,7 @@ from __future__ import annotations
 from .base import Action, Driver, FileInfo, Page, StorageEvent, Stored, chunks, collect
 from .bucket import Bucket
 from .config import BucketConfig, StorageConfig
+from .context import NotConfiguredError, current_storage
 from .drivers import LocalDriver, MemoryDriver
 from .errors import (
     FileNotFound,
@@ -48,7 +49,7 @@ from .errors import (
 from .paths import normalise
 from .policies import Owned, Private, Public, ReadOnly, Signed
 from .signing import SignedGrant, Signer
-from .storage import Storage, setup_storage
+from .storage import Storage, bucket, setup_storage
 from .uploads import stream_upload
 
 __all__ = [
@@ -60,6 +61,7 @@ __all__ = [
     "FileNotFound",
     "LocalDriver",
     "MemoryDriver",
+    "NotConfiguredError",
     "Owned",
     "Page",
     "PolicyRefused",
@@ -76,8 +78,10 @@ __all__ = [
     "StorageEvent",
     "Stored",
     "UnsafeKey",
+    "bucket",
     "chunks",
     "collect",
+    "current_storage",
     "normalise",
     "setup_storage",
     "stream_upload",

--- a/sillo/storage/context.py
+++ b/sillo/storage/context.py
@@ -1,0 +1,58 @@
+"""
+sillo.storage.context — the storage :func:`~sillo.storage.storage.setup_storage`
+built, reachable from anywhere.
+
+``setup_storage`` already builds one :class:`~sillo.storage.storage.Storage`
+and hands it back; the awkward part was ever afterwards, where a handler in a
+routes module either imported the application just to reach ``app.state`` (a
+circular import, since the application is what registers the routes) or
+threaded the instance through every function signature by hand — including
+into queue jobs and scripts, where there is no request to thread it from.
+
+:func:`current_storage` is the other way in: it reads the instance
+``setup_storage`` registered at startup, using the shared
+:class:`~sillo._internals.registry.InstanceRegistry`. It has nothing to do
+with the request lifecycle — a background job or a script reaches for it
+exactly the way a handler does.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from .._internals.registry import InstanceRegistry, NotConfiguredError
+
+if TYPE_CHECKING:
+    from .storage import Storage
+
+__all__ = ["NotConfiguredError", "current_storage", "register"]
+
+_registry: InstanceRegistry[Storage] = InstanceRegistry("storage")
+
+_EXAMPLE = (
+    'storage = setup_storage(app, StorageConfig(default="attachments", buckets={...}))'
+)
+
+
+def register(storage: Storage) -> None:
+    """Record *storage* as the one to hand back from now on.
+
+    Called by :func:`~sillo.storage.storage.setup_storage`; there is no
+    reason to call this directly outside a test of the registry itself.
+
+    Args:
+        storage: What ``setup_storage`` built.
+    """
+    _registry.register(storage)
+
+
+def current_storage() -> Storage:
+    """The storage ``setup_storage`` registered.
+
+    Returns:
+        The registered :class:`~sillo.storage.storage.Storage`.
+
+    Raises:
+        NotConfiguredError: If ``setup_storage`` has not run yet.
+    """
+    return _registry.current(setup="setup_storage", example=_EXAMPLE)

--- a/sillo/storage/storage.py
+++ b/sillo/storage/storage.py
@@ -3,7 +3,8 @@ sillo.storage.storage — the object on ``app.state``, and how it gets there.
 
 ``setup_storage(app, config)`` follows ``setup_record``: build the thing, put it
 on ``app.state``, register the lifecycle hooks, return it.  A project holds the
-:class:`Storage` and asks it for buckets.
+:class:`Storage` and asks it for buckets — or, anywhere at all, calls
+``sillo.storage.bucket(...)`` and lets :mod:`.context` find it.
 """
 
 from __future__ import annotations
@@ -13,11 +14,12 @@ from typing import Any
 
 from .bucket import Bucket
 from .config import BucketConfig, StorageConfig
+from .context import current_storage, register
 from .drivers import LocalDriver, MemoryDriver
 from .policies import Private
 from .signing import Signer
 
-__all__ = ["Storage", "setup_storage"]
+__all__ = ["Storage", "bucket", "setup_storage"]
 
 logger = logging.getLogger("sillo.storage")
 
@@ -161,6 +163,7 @@ def setup_storage(app: Any, config: StorageConfig, *, secret: str = "") -> Stora
     storage = Storage(config, secret=secret or _app_secret(app))
     app.state["storage"] = storage
     app.on_shutdown(storage.close)
+    register(storage)
 
     if config.serve:
         from .routes import mount
@@ -169,6 +172,33 @@ def setup_storage(app: Any, config: StorageConfig, *, secret: str = "") -> Stora
 
     logger.debug("storage ready — %s", storage)
     return storage
+
+
+def bucket(name: str = "") -> Bucket:
+    """The named bucket of the storage :func:`setup_storage` registered.
+
+    Shorthand for ``current_storage().bucket(name)``, for code that has no
+    reason to hold the whole :class:`Storage` — a route handler, a queue job,
+    a script, anywhere after startup::
+
+        from sillo.storage import bucket
+
+        @app.post("/avatar")
+        async def upload_avatar(request, response):
+            stored = await bucket("avatars").put(key, upload, user=request.user)
+            ...
+
+    Args:
+        name: The bucket's name, or empty for the configuration's default.
+
+    Returns:
+        The bucket.
+
+    Raises:
+        NotConfiguredError: If ``setup_storage`` has not run yet.
+        KeyError: If no such bucket was declared.
+    """
+    return current_storage().bucket(name)
 
 
 def _app_secret(app: Any) -> str:

--- a/tests/test_internals/test_registry.py
+++ b/tests/test_internals/test_registry.py
@@ -1,0 +1,81 @@
+"""
+InstanceRegistry — the primitive mail and storage share for "the instance
+setup_x built, reachable from anywhere".
+
+Deliberately no request, no task, no ASGI app anywhere in this file: the
+property under test is that a plain register/current pair works the same way
+regardless of what is calling it.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from sillo._internals.registry import InstanceRegistry, NotConfiguredError
+
+
+@pytest.fixture
+def registry() -> InstanceRegistry[str]:
+    return InstanceRegistry("thing")
+
+
+def _current(registry: InstanceRegistry[str]) -> str:
+    return registry.current(setup="setup_thing", example="setup_thing(app)")
+
+
+def test_current_raises_before_anything_is_registered(
+    registry: InstanceRegistry[str],
+) -> None:
+    with pytest.raises(NotConfiguredError):
+        _current(registry)
+
+
+def test_error_names_the_thing_and_the_setup_call(
+    registry: InstanceRegistry[str],
+) -> None:
+    with pytest.raises(NotConfiguredError) as excinfo:
+        _current(registry)
+
+    message = str(excinfo.value)
+    assert "thing" in message
+    assert "setup_thing" in message
+    assert "setup_thing(app)" in message
+
+
+def test_register_makes_current_available(registry: InstanceRegistry[str]) -> None:
+    registry.register("instance-a")
+    assert _current(registry) == "instance-a"
+
+
+def test_registering_again_replaces_the_previous_instance(
+    registry: InstanceRegistry[str],
+) -> None:
+    registry.register("instance-a")
+    registry.register("instance-b")
+    assert _current(registry) == "instance-b"
+
+
+def test_current_is_reachable_with_no_request_or_task_in_play(
+    registry: InstanceRegistry[str],
+) -> None:
+    """The whole point: register once, read back from a plain function call.
+
+    No fixture here builds an app, a request, or a task — reading the
+    instance back is exactly as available as calling any other function.
+    """
+    registry.register("instance-a")
+
+    def deep_in_a_queue_job() -> str:
+        return _current(registry)
+
+    assert deep_in_a_queue_job() == "instance-a"
+
+
+def test_two_registries_with_the_same_label_do_not_share_state() -> None:
+    first = InstanceRegistry("duplicate-label")
+    second = InstanceRegistry("duplicate-label")
+
+    first.register("only-on-first")
+
+    with pytest.raises(NotConfiguredError):
+        _current(second)

--- a/tests/test_mail/test_context.py
+++ b/tests/test_mail/test_context.py
@@ -1,0 +1,80 @@
+"""
+sillo.mail.context, wired through setup_mail.
+
+Same shape as tests/test_storage/test_context.py — the primitive itself is
+covered in test_internals/test_registry.py; this proves setup_mail actually
+registers the client and that send_email()/current_mail() reach it with no
+request in hand, which matters more here than for storage: mail is sent from
+queue jobs at least as often as from a request handler.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from sillo import SilloApp
+from sillo._internals.registry import InstanceRegistry
+from sillo.mail import (
+    MailConfig,
+    NotConfiguredError,
+    current_mail,
+    send_email,
+    setup_mail,
+)
+from sillo.mail import context as mail_context
+
+
+def _make_client(default_from: str):
+    application = SilloApp(title="Context")
+    return setup_mail(
+        application, MailConfig(default_from=default_from, suppress_send=True)
+    )
+
+
+def test_send_email_is_reachable_right_after_setup_mail():
+    """No request, no app.get, no middleware — just setup_mail then send_email()."""
+    _make_client("noreply-a@example.com")
+
+    result = asyncio.run(send_email("someone@example.com", "Hi", body="Hello"))
+    assert result.success is True
+
+
+def test_current_mail_matches_what_setup_mail_returned():
+    client = _make_client("noreply-a@example.com")
+
+    assert current_mail() is client
+
+
+def test_send_email_is_reachable_from_a_plain_function_no_request_involved():
+    """Stands in for a queue job: a plain function with no request at all."""
+    _make_client("noreply-a@example.com")
+
+    async def deep_in_a_queue_job() -> bool:
+        result = await send_email("someone@example.com", "Hi", body="Hello")
+        return result.success
+
+    assert asyncio.run(deep_in_a_queue_job()) is True
+
+
+def test_current_mail_before_setup_mail_raises(monkeypatch):
+    """A fresh registry, so this does not depend on test order."""
+    monkeypatch.setattr(mail_context, "_registry", InstanceRegistry("mail client"))
+
+    with pytest.raises(NotConfiguredError) as excinfo:
+        mail_context.current_mail()
+
+    message = str(excinfo.value)
+    assert "setup_mail" in message
+    assert "mail client" in message
+
+
+def test_a_second_setup_mail_call_replaces_the_registered_client():
+    """setup_mail is process-global, not per-application — see the matching
+    storage test for why that is the deliberate trade of not being tied to
+    any request or app object."""
+    _make_client("noreply-a@example.com")
+    client_b = _make_client("noreply-b@example.com")
+
+    assert current_mail() is client_b

--- a/tests/test_storage/test_context.py
+++ b/tests/test_storage/test_context.py
@@ -1,0 +1,97 @@
+"""
+sillo.storage.context, wired through setup_storage.
+
+test_internals/test_registry.py already proves the primitive is sound on its
+own; what is worth proving here is the wiring itself — that setup_storage
+actually registers the instance, that bucket()/current_storage() reach it with
+no request or app in hand, and that the last application to call setup_storage
+in a process is the one they return.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from sillo import SilloApp
+from sillo.storage import (
+    BucketConfig,
+    NotConfiguredError,
+    Public,
+    StorageConfig,
+    bucket,
+    current_storage,
+    setup_storage,
+)
+
+SECRET = "an-application-secret-long-enough"
+
+
+def _make_app(tmp_path, default: str):
+    application = SilloApp(title="Context")
+    application.state["secret_key"] = SECRET
+
+    storage = setup_storage(
+        application,
+        StorageConfig(
+            default=default,
+            buckets={
+                default: BucketConfig(
+                    driver="local", root=str(tmp_path / default), policy=Public()
+                ),
+            },
+        ),
+    )
+    return application, storage
+
+
+def test_bucket_is_reachable_right_after_setup_storage(tmp_path):
+    """No request, no app call, no middleware — just setup_storage then bucket()."""
+    _make_app(tmp_path, "attachments")
+
+    assert bucket().name == "attachments"
+
+
+def test_current_storage_matches_what_setup_storage_returned(tmp_path):
+    _application, storage = _make_app(tmp_path, "attachments")
+
+    assert current_storage() is storage
+
+
+def test_bucket_is_reachable_from_a_plain_function_no_request_involved(tmp_path):
+    """Stands in for a queue job or script: a function with no request at all."""
+    _make_app(tmp_path, "attachments")
+
+    def deep_in_a_queue_job() -> str:
+        return bucket().name
+
+    assert deep_in_a_queue_job() == "attachments"
+
+
+def test_current_storage_before_setup_storage_raises(monkeypatch, tmp_path):
+    """A fresh registry, so this does not depend on test order."""
+    from sillo._internals.registry import InstanceRegistry
+    from sillo.storage import context as storage_context
+
+    monkeypatch.setattr(storage_context, "_registry", InstanceRegistry("storage"))
+
+    with pytest.raises(NotConfiguredError) as excinfo:
+        storage_context.current_storage()
+
+    message = str(excinfo.value)
+    assert "setup_storage" in message
+    assert "storage" in message
+
+
+def test_a_second_setup_storage_call_replaces_the_registered_instance(tmp_path):
+    """setup_storage is process-global, not per-application.
+
+    Calling it again — a second application in the same process, the shape a
+    test suite makes — replaces what bucket()/current_storage() return. This
+    is a deliberate consequence of not being tied to any request or app
+    object: there is exactly one registered storage at a time.
+    """
+    _make_app(tmp_path / "a", "receipts")
+    _application_b, storage_b = _make_app(tmp_path / "b", "avatars")
+
+    assert current_storage() is storage_b
+    assert bucket().name == "avatars"


### PR DESCRIPTION
## Summary

- Adds `sillo._internals.registry.InstanceRegistry` — a plain slot, filled once when `setup_x(app, config)` runs, read back from anywhere. No `ContextVar`, no middleware, nothing tied to the request lifecycle.
- `sillo.storage` gets `current_storage()` and `bucket(name)`; `sillo.mail` gets `current_mail()` and `send_email(...)`. Both work identically in a route handler, a queue job, or a script.
- Asking before `setup_storage`/`setup_mail` has run raises `NotConfiguredError` naming the call that was skipped, instead of handing back `None`.
- `app.state["storage"]` / `app.state["mail_client"]` are untouched — this is additive for code that would rather not hold the application object.

## Why not request-scoped

An earlier draft of this bound the instance per request via middleware, the same way `sillo_inertia`'s `current_inertia()` works — the right call there, since an Inertia response is a function of the request answering it. Mail and storage don't share that property: a queue job sending a receipt has no request to bind from, and that's not an edge case for either subsystem. Registering once at startup removes the request from the question entirely, at the cost of the registry holding one instance at a time (whichever `setup_x` call registered most recently) rather than being scoped per application — the same "one instance per app" assumption `app.state` already made, made explicit at process scope.

Full writeup: `docs/docs/src/content/docs/advanced/context-binding.md`.

## Test plan

- [x] `tests/test_internals/test_registry.py` — the primitive alone, no app/request involved
- [x] `tests/test_storage/test_context.py`, `tests/test_mail/test_context.py` — wiring through real `setup_storage`/`setup_mail`
- [x] Full suite: 4944 passed, 66 skipped
- [x] ruff + ruff format clean; mypy clean on every file this PR touches (8 pre-existing errors in `sillo/mail/client.py` are unchanged from `main`)
- [x] Docs site builds (255 pages, new page renders)

🤖 Generated with [Claude Code](https://claude.com/claude-code)