### PR TITLE
Add per-gate unauthorized/forbidden hooks to useAuth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `sillo.storage.current_storage()` and `sillo.storage.bucket(name)` — reach the `Storage` `setup_storage` registered, from a handler, a queue job, or a script, without the application object or a request.
 - `sillo.mail.current_mail()` and `sillo.mail.send_email(...)` — same shape, for the `MailClient` `setup_mail` registered.
 - `sillo._internals.registry.InstanceRegistry`, the shared internal mechanism behind both: a plain slot filled once at startup and read from anywhere, raising `NotConfiguredError` — not `None` — when asked before `setup_x` has run. Documented in [Instance Registry](https://sillo.build/advanced/context-binding/).
+- `useAuth(unauthorized=..., forbidden=...)` — per-route hooks that answer a failed gate directly instead of raising `AuthenticationFailed`/`PermissionDenied` for the global exception handler to catch. Each is called as `hook(request, response)`, sync or async, and its return value is sent as the response with the route handler never reached. Unset, a gate behaves exactly as before.
 
 ## [0.2.0] - 2026-08-18
 

--- a/docs/docs/src/content/docs/guides/authentication.md
+++ b/docs/docs/src/content/docs/guides/authentication.md
@@ -231,6 +231,46 @@ async def on_401(request, response, exc):
 | Scope mismatch | 401 | `AuthenticationFailed` |
 | Permission denied | 403 | `PermissionDenied` |
 
+`add_exception_handler` is global — every route whose gate raises that exception
+goes through it. When one particular route needs to fail differently — a page
+that redirects to `/login` while your API returns JSON — give that gate its own
+`unauthorized`/`forbidden` hooks instead of routing failures through a shared
+handler that then has to branch:
+
+```python
+@app.get(
+    "/dashboard",
+    auth=useAuth(
+        unauthorized=lambda request, response: response.redirect("/login"),
+    ),
+)
+async def dashboard(request, response): ...
+
+@app.get(
+    "/api/orders",
+    auth=useAuth(
+        permissions=["orders:read"],
+        unauthorized=lambda request, response: response.json(
+            {"error": "sign_in_required"}, status_code=401
+        ),
+        forbidden=lambda request, response: response.json(
+            {"error": "not_allowed"}, status_code=403
+        ),
+    ),
+)
+async def orders(request, response): ...
+```
+
+Each hook is called as `hook(request, response)` — sync or async, your choice —
+and whatever it returns becomes the response; the route handler never runs.
+`unauthorized` answers the 401 a missing or mismatched scheme would have
+raised, `forbidden` answers the 403 a missing permission would have raised.
+Set one, both, or neither — a gate with no hooks behaves exactly as before, so
+existing routes are unaffected. This is the finer-grained sibling of
+`add_exception_handler`, not a replacement for it: reach for a gate-level hook
+when one route needs its own answer, and for the global handler when every
+route protected by a given exception type should agree.
+
 ##  How it all connects
 
 ```mermaid

--- a/sillo/auth/use_auth.py
+++ b/sillo/auth/use_auth.py
@@ -22,6 +22,40 @@ methods::
     async def feed(request, response):
         user = request.user  # may be UnauthenticatedUser
 
+A failed gate normally raises ``AuthenticationFailed`` (401) or
+``PermissionDenied`` (403), which the framework turns into a generic JSON
+error. Pass ``unauthorized`` and/or ``forbidden`` to answer a specific route
+differently — a redirect to a login page, a shaped error body, whatever the
+route needs — without touching global exception handling::
+
+    @router.get(
+        "/dashboard",
+        auth=useAuth(
+            unauthorized=lambda request, response: response.redirect("/login"),
+        ),
+    )
+    async def dashboard(request, response): ...
+
+    @router.get(
+        "/api/orders",
+        auth=useAuth(
+            permissions=["orders:read"],
+            unauthorized=lambda request, response: response.json(
+                {"error": "sign_in_required"}, status_code=401
+            ),
+            forbidden=lambda request, response: response.json(
+                {"error": "not_allowed"}, status_code=403
+            ),
+        ),
+    )
+    async def orders(request, response): ...
+
+Both are optional and independent: set one, both, or neither. Either may be a
+plain function or a coroutine function, and each is called as
+``hook(request, response)``. Whatever it returns becomes the response for the
+request — the route handler never runs. Leaving a hook unset keeps the default
+exception for that failure mode, so existing routes are unaffected.
+
 Subclass to add custom logic::
 
     class OrgAuth(useAuth):
@@ -39,11 +73,13 @@ Subclass to add custom logic::
 
 from __future__ import annotations
 
-from collections.abc import Sequence
-from typing import TYPE_CHECKING
+from collections.abc import Awaitable, Callable, Sequence
+from typing import TYPE_CHECKING, Any, Union
 
 from sillo.auth.backend import AuthenticationBackend
 from sillo.auth.exceptions import AuthenticationFailed, PermissionDenied
+from sillo.core.helpers.async_helpers import is_async_callable
+from sillo.helpers.concurrency import run_in_threadpool
 from sillo.users.simple import SimpleUser
 
 if TYPE_CHECKING:
@@ -51,8 +87,14 @@ if TYPE_CHECKING:
     # drags the ORM into `import sillo` and makes the package unimportable
     # without the `record` extra. Both names are only ever annotations here,
     # and `from __future__ import annotations` keeps those unevaluated.
-    from sillo.core.http import Request
+    from sillo.core.http import Request, Response
     from sillo.users.base import BaseUser, UserProtocol
+
+#: A per-gate failure hook: sync or async, called as ``hook(request, response)``
+#: when the gate refuses the request. Whatever it returns is sent back as the
+#: response in place of the default ``AuthenticationFailed``/``PermissionDenied``
+#: error — the route handler is never reached.
+FailureHook = Callable[["Request", "Response"], Union[Any, Awaitable[Any]]]
 
 
 #: What the shipped backends used to report as ``AuthResult.scope``, mapped to
@@ -159,6 +201,8 @@ class useAuth:
         required: bool = True,
         schemes: list[str] | dict[str, list[str]] | None = None,
         all_of: bool = False,
+        unauthorized: FailureHook | None = None,
+        forbidden: FailureHook | None = None,
     ) -> None:
         """Initialise the authentication gate with scheme, permission, and backend config.
 
@@ -189,6 +233,13 @@ class useAuth:
                 ``False`` (the default) means any one will do, which OpenAPI
                 writes as separate requirement objects; ``True`` means all of
                 them, which OpenAPI writes as one object with several keys.
+            unauthorized: Called as ``hook(request, response)`` in place of
+                the default 401 when authentication is missing or the scheme
+                does not match. Its return value becomes the response and the
+                route handler does not run. May be sync or async. ``None``
+                (the default) keeps raising ``AuthenticationFailed``.
+            forbidden: The same, for the 403 a missing permission raises.
+                ``None`` (the default) keeps raising ``PermissionDenied``.
 
         Returns:
             None. This is a constructor that initialises the gate state.
@@ -211,6 +262,57 @@ class useAuth:
             else {name: list(value or []) for name, value in schemes.items()}
         )
         self.all_of: bool = all_of
+        self.unauthorized: FailureHook | None = unauthorized
+        self.forbidden: FailureHook | None = forbidden
+
+    async def guard(self, request: Request, response: Response) -> Any | None:
+        """Run the gate, and turn a failure into a response if this gate says how to.
+
+        The entry point the router calls — in preference to ``authenticate``
+        directly — because answering a failure with a custom response needs
+        ``response``, which ``authenticate`` was never given and whose
+        signature stays untouched so existing subclasses keep working.
+
+        Args:
+            request: The incoming request.
+            response: The outgoing response, handed to whichever hook fires.
+
+        Returns:
+            The hook's return value if ``authenticate`` raised and this gate
+            has a matching hook — the caller should send that back as the
+            response instead of invoking the route handler. ``None`` if
+            authentication passed, meaning the caller should proceed as usual.
+
+        Raises:
+            AuthenticationFailed: Authentication failed and no ``unauthorized``
+                hook is set on this gate.
+            PermissionDenied: A permission was missing and no ``forbidden``
+                hook is set on this gate.
+        """
+        try:
+            await self.authenticate(request)
+        except PermissionDenied:
+            if self.forbidden is None:
+                raise
+            return await self._run_hook(self.forbidden, request, response)
+        except AuthenticationFailed:
+            if self.unauthorized is None:
+                raise
+            return await self._run_hook(self.unauthorized, request, response)
+        return None
+
+    @staticmethod
+    async def _run_hook(hook: FailureHook, request: Request, response: Response) -> Any:
+        """Call a failure hook, awaiting it only if it is itself async.
+
+        A sync hook runs in the thread pool rather than inline, on the same
+        reasoning the router applies to a sync route handler: it is allowed to
+        do blocking work, and inlining it would block the event loop for
+        everyone else's requests while it does.
+        """
+        if is_async_callable(hook):
+            return await hook(request, response)
+        return await run_in_threadpool(hook, request, response)
 
     async def authenticate(self, request: Request) -> bool:
         """Run the authentication and authorisation gate before the route handler.

--- a/sillo/core/routing/router.py
+++ b/sillo/core/routing/router.py
@@ -644,7 +644,24 @@ class Route(BaseRoute):
                 injected[self._validated_param_name] = validated
 
         if self.auth is not None:
-            await self.auth.authenticate(request)
+            # `guard`, when the gate has one, in preference to `authenticate`
+            # directly: it is what lets a `useAuth`'s `unauthorized`/
+            # `forbidden` hooks answer the request themselves. `authenticate`
+            # alone never gets `response`, which those hooks need.
+            #
+            # `auth` is duck-typed rather than required to be a `useAuth`
+            # (see its `Any | None` annotation above), so a hand-built gate
+            # that only ever implemented `authenticate` — the documented
+            # extension point before `guard` existed — is called the way it
+            # always was rather than breaking on a method it was never asked
+            # to define.
+            guard = getattr(self.auth, "guard", None)
+            if guard is not None:
+                early_response = await guard(request, response)
+                if early_response is not None:
+                    return early_response
+            else:
+                await self.auth.authenticate(request)
 
         # Path parameters reach the handler as **kwargs. When one is also
         # declared with a validation marker, the validated value supersedes the

--- a/tests/test_auth/test_use_auth.py
+++ b/tests/test_auth/test_use_auth.py
@@ -5,10 +5,11 @@ import pytest
 from sillo.application import SilloApp
 from sillo.auth import AuthenticationMiddleware, BaseUser, useAuth
 from sillo.auth.backend import AuthenticationBackend
+from sillo.auth.exceptions import AuthenticationFailed
 from sillo.auth.model import AuthResult
-from sillo.users import SimpleUser, UnauthenticatedUser
 from sillo.core.http import Request, Response
 from sillo.testclient import AsyncTestClient
+from sillo.users import SimpleUser, UnauthenticatedUser
 
 
 class TestUser(BaseUser):
@@ -370,3 +371,279 @@ async def test_use_auth_subclass_custom_logic(test_client):
 
         res = await client.get("/custom", headers={"X-Auth": "valid", "X-Custom": "granted"})
         assert res.status_code == 200
+
+
+# ---------------------------------------------------------------------------
+# useAuth: unauthorized / forbidden hooks
+# ---------------------------------------------------------------------------
+#
+# `unauthorized` answers the 401 a missing/mismatched-scheme authentication
+# would have raised; `forbidden` answers the 403 a missing permission would
+# have raised. Both are optional, independent, and — unset — change nothing:
+# the gate keeps raising AuthenticationFailed/PermissionDenied exactly as it
+# always did, which the tests in this section confirm as much as the new
+# behaviour itself.
+
+
+async def test_unauthorized_hook_replaces_the_401(test_client):
+    app = SilloApp()
+    app.use(AuthenticationMiddleware(TestUser, AuthBackend()))
+
+    @app.get(
+        "/protected",
+        auth=useAuth(unauthorized=lambda req, res: res.json({"custom": True}, status_code=401)),
+    )
+    async def protected(req: Request, res: Response):
+        return res.json({"ok": True})
+
+    async with test_client(app) as client:
+        res = await client.get("/protected")
+        assert res.status_code == 401
+        assert res.json() == {"custom": True}
+
+
+async def test_unauthorized_hook_can_redirect(test_client):
+    app = SilloApp()
+    app.use(AuthenticationMiddleware(TestUser, AuthBackend()))
+
+    @app.get(
+        "/dashboard",
+        auth=useAuth(unauthorized=lambda req, res: res.redirect("/login")),
+    )
+    async def dashboard(req: Request, res: Response):
+        return res.json({"ok": True})
+
+    async with test_client(app) as client:
+        res = await client.get("/dashboard", follow_redirects=False)
+        assert res.status_code == 302
+        assert res.headers["location"] == "/login"
+
+
+async def test_unauthorized_hook_fires_on_scheme_mismatch_too(test_client):
+    """A wrong-scheme authentication is also `AuthenticationFailed` — the hook
+    has to cover that path, not only "no user at all"."""
+    app = SilloApp()
+    app.use(AuthenticationMiddleware(TestUser, AuthBackend()))
+
+    @app.get(
+        "/scoped",
+        auth=useAuth(
+            schemes=["sessionCookie"],
+            unauthorized=lambda req, res: res.json({"reason": "wrong-scheme"}, status_code=401),
+        ),
+    )
+    async def scoped(req: Request, res: Response):
+        return res.json({"ok": True})
+
+    async with test_client(app) as client:
+        res = await client.get("/scoped", headers={"X-Auth": "valid"})
+        assert res.status_code == 401
+        assert res.json() == {"reason": "wrong-scheme"}
+
+
+async def test_forbidden_hook_replaces_the_403(test_client):
+    app = SilloApp()
+    app.use(AuthenticationMiddleware(TestUser, AuthBackend()))
+
+    @app.get(
+        "/admin-only",
+        auth=useAuth(
+            permissions=["admin"],
+            forbidden=lambda req, res: res.json({"custom": True}, status_code=403),
+        ),
+    )
+    async def admin_only(req: Request, res: Response):
+        return res.json({"ok": True})
+
+    async with test_client(app) as client:
+        res = await client.get("/admin-only", headers={"X-Auth": "valid"})
+        assert res.status_code == 403
+        assert res.json() == {"custom": True}
+
+
+async def test_forbidden_hook_does_not_fire_on_401(test_client):
+    """An anonymous caller against a permission-gated route is still a 401,
+    not a 403 — `forbidden` must not be asked to answer for `unauthorized`."""
+    app = SilloApp()
+    app.use(AuthenticationMiddleware(TestUser, AuthBackend()))
+
+    @app.get(
+        "/admin-only",
+        auth=useAuth(
+            permissions=["admin"],
+            forbidden=lambda req, res: res.json({"wrong_hook": True}, status_code=403),
+        ),
+    )
+    async def admin_only(req: Request, res: Response):
+        return res.json({"ok": True})
+
+    async with test_client(app) as client:
+        res = await client.get("/admin-only")
+        assert res.status_code == 401
+        assert res.json() != {"wrong_hook": True}
+
+
+async def test_unauthorized_and_forbidden_are_independent(test_client):
+    app = SilloApp()
+    app.use(AuthenticationMiddleware(TestUser, AuthBackend()))
+
+    @app.get(
+        "/both",
+        auth=useAuth(
+            permissions=["admin"],
+            unauthorized=lambda req, res: res.json({"which": "unauthorized"}, status_code=401),
+            forbidden=lambda req, res: res.json({"which": "forbidden"}, status_code=403),
+        ),
+    )
+    async def both(req: Request, res: Response):
+        return res.json({"ok": True})
+
+    async with test_client(app) as client:
+        anon = await client.get("/both")
+        assert anon.status_code == 401 and anon.json() == {"which": "unauthorized"}
+
+        non_admin = await client.get("/both", headers={"X-Auth": "valid"})
+        assert non_admin.status_code == 403 and non_admin.json() == {"which": "forbidden"}
+
+
+async def test_an_async_hook_is_awaited(test_client):
+    app = SilloApp()
+    app.use(AuthenticationMiddleware(TestUser, AuthBackend()))
+
+    async def hook(req: Request, res: Response):
+        return res.json({"async": True}, status_code=401)
+
+    @app.get("/protected", auth=useAuth(unauthorized=hook))
+    async def protected(req: Request, res: Response):
+        return res.json({"ok": True})
+
+    async with test_client(app) as client:
+        res = await client.get("/protected")
+        assert res.status_code == 401
+        assert res.json() == {"async": True}
+
+
+async def test_a_sync_hook_still_runs_without_blocking_the_test(test_client):
+    """Exercises the thread-pool path `_run_hook` takes for a plain function."""
+    app = SilloApp()
+    app.use(AuthenticationMiddleware(TestUser, AuthBackend()))
+
+    def hook(req: Request, res: Response):
+        return res.json({"sync": True}, status_code=401)
+
+    @app.get("/protected", auth=useAuth(unauthorized=hook))
+    async def protected(req: Request, res: Response):
+        return res.json({"ok": True})
+
+    async with test_client(app) as client:
+        res = await client.get("/protected")
+        assert res.status_code == 401
+        assert res.json() == {"sync": True}
+
+
+async def test_the_route_handler_never_runs_when_a_hook_fires(test_client):
+    app = SilloApp()
+    app.use(AuthenticationMiddleware(TestUser, AuthBackend()))
+    handler_calls = []
+
+    @app.get(
+        "/protected",
+        auth=useAuth(unauthorized=lambda req, res: res.json({}, status_code=401)),
+    )
+    async def protected(req: Request, res: Response):
+        handler_calls.append(1)
+        return res.json({"ok": True})
+
+    async with test_client(app) as client:
+        await client.get("/protected")
+        assert handler_calls == []
+
+
+async def test_no_hooks_keeps_raising_authentication_failed(test_client):
+    """The default behaviour, unchanged, when neither hook is set."""
+    app = SilloApp()
+    app.use(AuthenticationMiddleware(TestUser, AuthBackend()))
+
+    @app.get("/protected", auth=useAuth())
+    async def protected(req: Request, res: Response):
+        return res.json({"ok": True})
+
+    async with test_client(app) as client:
+        res = await client.get("/protected")
+        assert res.status_code == 401
+        assert "Authentication failed" in res.text
+
+
+async def test_no_forbidden_hook_keeps_raising_permission_denied(test_client):
+    app = SilloApp()
+    app.use(AuthenticationMiddleware(TestUser, AuthBackend()))
+
+    @app.get("/admin-only", auth=useAuth(permissions=["admin"]))
+    async def admin_only(req: Request, res: Response):
+        return res.json({"ok": True})
+
+    async with test_client(app) as client:
+        res = await client.get("/admin-only", headers={"X-Auth": "valid"})
+        assert res.status_code == 403
+        assert "Permission denied" in res.text
+
+
+async def test_hooks_are_stored_on_the_instance():
+    """The plumbing `guard()` reads from — worth pinning directly, since a
+    typo in the attribute name would otherwise only show up as a hook that
+    silently never fires."""
+
+    def unauthorized_hook(req, res):
+        return None
+
+    def forbidden_hook(req, res):
+        return None
+
+    gate = useAuth(unauthorized=unauthorized_hook, forbidden=forbidden_hook)
+    assert gate.unauthorized is unauthorized_hook
+    assert gate.forbidden is forbidden_hook
+
+    bare = useAuth()
+    assert bare.unauthorized is None
+    assert bare.forbidden is None
+
+
+async def test_guard_returns_none_when_authentication_passes():
+    """`guard()` is what the router short-circuits on a non-None return —
+    confirm the success path gives it nothing to short-circuit on."""
+    app = SilloApp()
+    app.use(AuthenticationMiddleware(TestUser, AuthBackend()))
+    gate = useAuth(unauthorized=lambda req, res: res.json({}, status_code=401))
+
+    class FakeRequest:
+        def __init__(self):
+            self.scope = {"user": TestUser("1", "testuser"), "auth": None, "auth_scheme": None}
+
+    result = await gate.guard(FakeRequest(), response=None)
+    assert result is None
+
+
+async def test_a_custom_gate_without_guard_still_works(test_client):
+    """`auth=` is duck-typed (`Any | None`), so a hand-built gate that only
+    ever implemented `authenticate` — the extension point documented before
+    `guard` existed — must keep working through the router's fallback."""
+
+    class BareGate:
+        async def authenticate(self, request):
+            if request.headers.get("X-Auth") != "valid":
+                raise AuthenticationFailed
+            return True
+
+    app = SilloApp()
+    app.use(AuthenticationMiddleware(TestUser, AuthBackend()))
+
+    @app.get("/bare", auth=BareGate())
+    async def bare(req: Request, res: Response):
+        return res.json({"ok": True})
+
+    async with test_client(app) as client:
+        denied = await client.get("/bare")
+        assert denied.status_code == 401
+
+        allowed = await client.get("/bare", headers={"X-Auth": "valid"})
+        assert allowed.status_code == 200


### PR DESCRIPTION
## Summary

A failed `useAuth` gate has always raised `AuthenticationFailed` (401) or `PermissionDenied` (403), leaving `add_exception_handler` as the only way to customise the response — global, per exception type, every route protected by that type going through the same handler. There was no way for one route to answer differently from the rest without routing failures through a shared handler that then branches.

```python
@app.get(
    "/dashboard",
    auth=useAuth(
        unauthorized=lambda request, response: response.redirect("/login"),
    ),
)
async def dashboard(request, response): ...

@app.get(
    "/api/orders",
    auth=useAuth(
        permissions=["orders:read"],
        unauthorized=lambda request, response: response.json(
            {"error": "sign_in_required"}, status_code=401
        ),
        forbidden=lambda request, response: response.json(
            {"error": "not_allowed"}, status_code=403
        ),
    ),
)
async def orders(request, response): ...
```

Each hook is called as `hook(request, response)`, sync or async, and its return value becomes the response — the route handler never runs. Both are optional and independent; a gate with neither keeps raising the exceptions exactly as before.

## Design notes

- **`useAuth.authenticate(request)` is unchanged** — same signature, same exceptions, still the method the docstring's subclass example overrides — because it never receives `response`, which the hooks need.
- The new entry point is **`guard(request, response)`**, which runs `authenticate` and turns a caught exception into a hook's response when one is set.
- The router calls `guard` when the gate has one and **falls back to calling `authenticate` directly otherwise**, since `auth=` is duck-typed (`Any | None`) and a hand-built gate that only ever implemented `authenticate` — the documented extension point before this PR — must not break on a method it was never asked to define.

## Coverage

My new code: 100% of it exercised. The two changed files sit at 94–95% coverage against the full suite; every uncovered line in both is pre-existing code on lines this PR did not touch. Project-wide coverage is 91.57% locally (no Redis). `fail_under` stays at 90 rather than moving to 92 — the shortfall against 92% is in unrelated pre-existing modules (the scheduler, `work/task.py`), and raising the floor here would fail CI over code this PR never went near.

## Test plan

- [x] 14 new tests: both hooks firing, both left unset, hooks kept independent (a permission failure doesn't trigger `unauthorized` and vice versa), a scheme mismatch (also 401, not just "no user at all"), sync and async hooks, the route handler never running when a hook fires, and the duck-typed-gate fallback.
- [x] Full suite: `5094 passed, 60 skipped, 0 failed`
- [x] `ruff check` clean on all changed files
- [x] `mypy sillo` — zero new errors (checked every reported line against the diff hunks; all pre-existing)
- [x] Docs: `useAuth` module docstring, and a new subsection in `guides/authentication.md` placed right after the global `add_exception_handler` example, framed as its finer-grained sibling rather than a replacement
- [x] `CHANGELOG.md` entry under `[Unreleased] / Added`

